### PR TITLE
Remove namespace value from CR yaml to allow local deploy

### DIFF
--- a/opendatahub.yaml
+++ b/opendatahub.yaml
@@ -2,7 +2,6 @@ apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:
   name: opendatahub
-  namespace: opendatahub
 spec:
   applications:
   - kustomizeConfig:


### PR DESCRIPTION
The deployer always passes the -n namespace flag to oc, so
remove the namespace value from the yaml itself to allow
creation of a kfdef in any namespace when ODH_CR_NAMESPACE
is set.