### PR TITLE
Use the Authentication overlay for odh-dashboard

### DIFF
--- a/opendatahub.yaml
+++ b/opendatahub.yaml
@@ -33,6 +33,8 @@ spec:
         path: jupyterhub/notebook-images
     name: notebook-images
   - kustomizeConfig:
+      overlays:
+        - authentication
       repoRef:
         name: manifests
         path: odh-dashboard


### PR DESCRIPTION
This points our kfdef at the Authentication overlay for the ODH
Dashboard, which will configure it with an OAuth proxy to authenticate
and authorize users.