### PR TITLE
Change the tag for 11.0.3-cuda-s2i-py38-ubi8 to nb-1

### DIFF
--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -249,7 +249,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-python-container'
-        ref: v0.0.1
+        ref: nb-1
       contextDir: '3.8'
     triggers:
       - type: ImageChange


### PR DESCRIPTION
We'll use "nb-x" for tags to distinguish them as tags to use for
notebook build references