### PR TITLE
Increase prometheus memory limit to 2Gi

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -75,10 +75,10 @@ spec:
         resources:
           limits:
             cpu: 400m
-            memory: 3500Mi
+            memory: 4Gi
           requests:
             cpu: 200m
-            memory: 1Gi
+            memory: 2Gi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:


### PR DESCRIPTION
The prometheus container was getting OOMKilled. This doubles its memory
limit.