### PR TITLE
Bump up s2i base version nb-2 for the nvcc fix

### DIFF
--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -167,7 +167,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-base-container'
-        ref: nb-1
+        ref: nb-2
       contextDir: core
     triggers:
       - type: ImageChange
@@ -208,7 +208,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-base-container'
-        ref: nb-1
+        ref: nb-2
       contextDir: base
     triggers:
       - type: ImageChange


### PR DESCRIPTION
Bump up s2i base version nb-2 for the nvcc fix
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

Related-to: https://github.com/red-hat-data-services/s2i-base-container/pull/3