### PR TITLE
Set tags for cuda buildchain repositories

### DIFF
--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -332,7 +332,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-minimal-notebook'
-        ref: python38
+        ref: nb-1
     triggers:
       - type: ImageChange
         imageChange: {}
@@ -371,7 +371,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook'
-        ref: python38
+        ref: nb-1
     triggers:
       - type: ImageChange
         imageChange: {}
@@ -410,7 +410,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-pytorch-notebook'
-        ref: python38
+        ref: nb-1
     triggers:
       - type: ImageChange
         imageChange: {}


### PR DESCRIPTION
Add tags of the form "nb-N" for the rest of the cuda build chain
repositories in red-hat-data-services.  We did this for the
base images, add tags for minimal, pytorch, and tensorflow as
well so that the notebook source does not change for a release
because of a commit to the repository.