### PR TITLE
Add network policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ADD consolelink $HOME/consolelink
 ADD groups $HOME/groups
 ADD jupyterhub $HOME/jupyterhub
 ADD partners $HOME/partners
+ADD network $HOME/network
 
 RUN chmod 755 $HOME/deploy.sh && \
     chmod 644 $HOME/opendatahub.yaml && \
@@ -33,6 +34,7 @@ RUN chmod 755 $HOME/deploy.sh && \
     chmod 644 -R $HOME/monitoring && \
     chmod 644 -R $HOME/groups && \
     chmod 644 -R $HOME/jupyterhub && \
+    chmod 644 -R $HOME/network && \
     chown 1001:0 -R $HOME &&\
     chmod ug+rwx -R $HOME
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -198,4 +198,7 @@ else
   echo "The Anaconda base secret (${kind}/${resource}) has been modified. Skipping apply."
 fi
 
+# Add network policies
+oc apply -n ${ODH_PROJECT} -f network/applications_network_policy.yaml
+
 oc apply -n $ODH_PROJECT -f jupyterhub/cuda-11.0.3/manifests.yaml

--- a/network/applications_network_policy.yaml
+++ b/network/applications_network_policy.yaml
@@ -1,0 +1,33 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: redhat-ods-applications
+spec:
+  podSelector: {}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8081
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              opendatahub.io/generated-namespace: 'true'
+  egress:
+    - ports:
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 8081
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              opendatahub.io/generated-namespace: 'true'
+  policyTypes:
+    - Ingress
+    - Egress


### PR DESCRIPTION
This commit adds network policies to the `redhat-ods-applications` namespace. This adds rules that ensure we only have the needed traffic between the generated namespaces.