### PR TITLE
Add jupyterhub sizes ConfigMap

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -181,6 +181,15 @@ sed -i "s#<rhods-dashboard-url>#$odh_dashboard_route#g" consolelink/consolelink.
 oc apply -f consolelink/consolelink.yaml
 
 kind="configmap"
+resource="rhods-jupyterhub-sizes"
+
+if oc::object::safe::to::apply ${kind} ${resource}; then
+  oc apply -n ${ODH_PROJECT} -f jupyterhub/sizes/jupyterhub-singleuser-profiles-sizes-configmap.yaml
+else
+  echo "The sizes ConfigMap (${kind}/${resource}) has been modified. Skipping apply."
+fi
+
+kind="configmap"
 resource="rhods-groups-config"
 
 if oc::object::safe::to::apply ${kind} ${resource}; then

--- a/jupyterhub/sizes/jupyterhub-singleuser-profiles-sizes-configmap.yaml
+++ b/jupyterhub/sizes/jupyterhub-singleuser-profiles-sizes-configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rhods-jupyterhub-sizes
+  labels:
+    jupyterhub: singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+      sizes:
+      - name: Small
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: 1
+          limits:
+            memory: 8Gi
+            cpu: 2
+      - name: Medium
+        resources:
+          requests:
+            memory: 24Gi
+            cpu: 3
+          limits:
+            memory: 24Gi
+            cpu: 6
+      - name: Large
+        resources:
+          requests:
+            memory: 56Gi
+            cpu: 7
+          limits:
+            memory: 56Gi
+            cpu: 14
+      - name: X Large
+        resources:
+            requests:
+              memory: 120Gi
+              cpu: 15
+            limits:
+              memory: 120Gi
+              cpu: 30

--- a/opendatahub.yaml
+++ b/opendatahub.yaml
@@ -23,7 +23,6 @@ spec:
       overlays:
         - jupyterhub-db-deployment-patch
         - jupyterhub-deployment-patch
-        - sizes
         - ui-config
       repoRef:
         name: manifests


### PR DESCRIPTION
This commit moves the 'odh-jupyterhub-sizes' ConfigMap from odh-manifests
to deployer. This required so that users can configure sizes without the ConfigMap
getting overwritten by the operator

[RHODS-982](https://issues.redhat.com/browse/RHODS-982)
odh-manifests PR: https://github.com/red-hat-data-services/odh-manifests/pull/128 