### PR TITLE
Add network policies to all namespaces

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -218,6 +218,6 @@ else
 fi
 
 # Add network policies
-oc apply -n ${ODH_PROJECT} -f network/applications_network_policy.yaml
+oc apply -f network/
 
 oc apply -n $ODH_PROJECT -f jupyterhub/cuda-11.0.3/manifests.yaml

--- a/network/applications_network_policy.yaml
+++ b/network/applications_network_policy.yaml
@@ -2,6 +2,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: redhat-ods-applications
+  namespace: redhat-ods-applications
 spec:
   podSelector: {}
   ingress:

--- a/network/monitoring_network_policy.yaml
+++ b/network/monitoring_network_policy.yaml
@@ -1,0 +1,27 @@
+# Defines ingress rules for specific port. These ports are defined by
+# the services residing in redhat-ods-monitoring. namespaceSelector
+# ensures that traffic from only the desired namespaces is allowed
+
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: redhat-ods-monitoring
+  namespace: redhat-ods-monitoring
+spec:
+  podSelector: {}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 9115
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP
+          port: 9091
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              opendatahub.io/generated-namespace: 'true'
+  policyTypes:
+    - Ingress

--- a/network/operator_network_policy.yaml
+++ b/network/operator_network_policy.yaml
@@ -1,0 +1,20 @@
+# Rules defined allow traffic only from the desired namespaces to the rhods-operator
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: redhat-ods-operator
+  namespace: redhat-ods-operator
+spec:
+  podSelector:
+    matchLabels:
+      name: rhods-operator
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              opendatahub.io/generated-namespace: 'true'
+  policyTypes:
+    - Ingress
+
+
+


### PR DESCRIPTION
This commit adds network policies to redhat-ods-operator and redhat-ods-monitoring
namespaces. This ensures tha only desired traffic is allowed in the respective
namespaces.

Jira Issue: https://issues.redhat.com/browse/RHODS-680