### PR TITLE
RBAC for dedicated-admins in select namespaces if installed on OSD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY opendatahub.yaml $HOME
 COPY opendatahub-osd.yaml $HOME
 COPY rhods-monitoring.yaml $HOME
 COPY rhods-notebooks.yaml $HOME
+COPY rhods-osd-configs.yaml $HOME
 ADD monitoring $HOME/monitoring
 ADD consolelink $HOME/consolelink
 ADD groups $HOME/groups
@@ -36,6 +37,7 @@ RUN chmod 755 $HOME/deploy.sh && \
     chmod 644 $HOME/opendatahub-osd.yaml && \
     chmod 644 $HOME/rhods-monitoring.yaml && \
     chmod 644 $HOME/rhods-notebooks.yaml && \
+    chmod 644 $HOME/rhods-osd-configs.yaml && \
     chmod 644 -R $HOME/monitoring && \
     chmod 644 -R $HOME/groups && \
     chmod 644 -R $HOME/jupyterhub && \

--- a/rhods-osd-configs.yaml
+++ b/rhods-osd-configs.yaml
@@ -1,0 +1,15 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: rhods-osd-config
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: osd-configs
+      name: osd-configs
+  repos:
+  - name: manifests
+    uri: file:///opt/manifests/odh-manifests.tar.gz
+  version: v1.0.0


### PR DESCRIPTION
- Grant CRUD for CMs, ISs, BCs, Builds and Secrets on the applications and JH notebooks namespaces if install target is OpenShift Dedicated
- dedicated-admins group does not exist if not on OSD, so don't install otherwise