### PR TITLE
Replace odh-dashboard -> rhods-dashboard

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -188,7 +188,7 @@ oc apply -f monitoring/jupyterhub-route.yaml -n $ODH_PROJECT
 oc apply -f monitoring/rhods-dashboard-route.yaml -n $ODH_PROJECT
 
 jupyterhub_host=$(oc::wait::object::availability "oc get route jupyterhub -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
-rhods_dashboard_host=$(oc::wait::object::availability "oc get route odh-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
+rhods_dashboard_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
 
 sed -i "s/<jupyterhub_host>/$jupyterhub_host/g" monitoring/prometheus/prometheus.yaml
 sed -i "s/<rhods_dashboard_host>/$rhods_dashboard_host/g" monitoring/prometheus/prometheus.yaml
@@ -250,9 +250,9 @@ oc::wait::object::availability "oc get secret grafana-datasources -n $ODH_MONITO
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/grafana-dashboards
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/grafana/grafana.yaml
 
-# Add consoleLink CR to provide a link to the odh-dashboard via the Application Launcher in OpenShift
+# Add consoleLink CR to provide a link to the rhods-dashboard via the Application Launcher in OpenShift
 cluster_domain=$(oc get ingresses.config.openshift.io cluster --template {{.spec.domain}})
-odh_dashboard_route="https://odh-dashboard-$ODH_PROJECT.$cluster_domain"
+odh_dashboard_route="https://rhods-dashboard-$ODH_PROJECT.$cluster_domain"
 sed -i "s#<rhods-dashboard-url>#$odh_dashboard_route#g" consolelink/consolelink.yaml
 oc apply -f consolelink/consolelink.yaml
 

--- a/monitoring/prometheus/blackbox-exporter-common.yaml
+++ b/monitoring/prometheus/blackbox-exporter-common.yaml
@@ -48,7 +48,7 @@ spec:
           command:
             - /bin/sh
             - '-c'
-            - for i in `seq 1 230`; do sleep 10; echo "Waiting for odh-dashboard service to become available..."; if curl -s -k https://odh-dashboard.redhat-ods-applications.svc:8443; then exit 0; fi; done; exit 1
+            - for i in `seq 1 230`; do sleep 10; echo "Waiting for rhods-dashboard service to become available..."; if curl -s -k https://rhods-dashboard.redhat-ods-applications.svc:8443; then exit 0; fi; done; exit 1
       containers:
       - image: quay.io/prometheus/blackbox-exporter:v0.18.0
         name: blackbox-exporter

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -336,89 +336,89 @@ data:
       - name: SLOs - ODH Dashboard
         rules:
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[1d]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[1d]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[1d]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[1d]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate1d
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[1h]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[1h]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[1h]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[1h]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate1h
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[2h]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[2h]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[2h]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[2h]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate2h
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[30m]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[30m]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[30m]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[30m]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate30m
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[3d]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[3d]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[3d]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[3d]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate3d
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[5m]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[5m]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[5m]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[5m]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate5m
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard",code=~"5.."}[6h]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[6h]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="odh-dashboard"}[6h]))
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[6h]))
           labels:
-            route: odh-dashboard
+            route: rhods-dashboard
           record: haproxy_backend_http_responses_total:burnrate6h
 
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[1d])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[1d])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate1d
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[1h])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[1h])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate1h
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[2h])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[2h])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate2h
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[30m])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[30m])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate30m
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[3d])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[3d])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate3d
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[5m])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[5m])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate5m
         - expr: |
-            1 - avg_over_time(probe_success{instance=~"odh-dashboard-.*", job="user_facing_endpoints_status"}[6h])
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[6h])
           labels:
-            instance: odh-dashboard
+            instance: rhods-dashboard
           record: probe_success:burnrate6h
 
       - name: SLOs - JupyterHub DB
@@ -512,9 +512,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate5m{route=~"jupyterhub|odh-dashboard"}) by (route) > (14.40 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate5m{route=~"jupyterhub|rhods-dashboard"}) by (route) > (14.40 * (1-0.98000))
             and
-            sum(haproxy_backend_http_responses_total:burnrate1h{route=~"jupyterhub|odh-dashboard"}) by (route) > (14.40 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate1h{route=~"jupyterhub|rhods-dashboard"}) by (route) > (14.40 * (1-0.98000))
           for: 2m
           labels:
             severity: critical
@@ -524,9 +524,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate30m{route=~"jupyterhub|odh-dashboard"}) by (route) > (6.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate30m{route=~"jupyterhub|rhods-dashboard"}) by (route) > (6.00 * (1-0.98000))
             and
-            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"jupyterhub|odh-dashboard"}) by (route) > (6.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"jupyterhub|rhods-dashboard"}) by (route) > (6.00 * (1-0.98000))
           for: 15m
           labels:
             severity: critical
@@ -536,9 +536,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate2h{route=~"jupyterhub|odh-dashboard"}) by (route) > (3.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate2h{route=~"jupyterhub|rhods-dashboard"}) by (route) > (3.00 * (1-0.98000))
             and
-            sum(haproxy_backend_http_responses_total:burnrate1d{route=~"jupyterhub|odh-dashboard"}) by (route) > (3.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate1d{route=~"jupyterhub|rhods-dashboard"}) by (route) > (3.00 * (1-0.98000))
           for: 1h
           labels:
             severity: warning
@@ -548,9 +548,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"jupyterhub|odh-dashboard"}) by (route) > (1.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"jupyterhub|rhods-dashboard"}) by (route) > (1.00 * (1-0.98000))
             and
-            sum(haproxy_backend_http_responses_total:burnrate3d{route=~"jupyterhub|odh-dashboard"}) by (route) > (1.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate3d{route=~"jupyterhub|rhods-dashboard"}) by (route) > (1.00 * (1-0.98000))
           for: 3h
           labels:
             severity: warning
@@ -586,9 +586,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate5m{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate5m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
             and
-            sum(probe_success:burnrate1h{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate1h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
           for: 2m
           labels:
             severity: critical
@@ -598,9 +598,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate30m{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate30m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate6h{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
           for: 15m
           labels:
             severity: critical
@@ -610,9 +610,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate2h{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate2h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate1d{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate1d{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
           for: 1h
           labels:
             severity: warning
@@ -622,9 +622,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/master/RHODS/README.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate6h{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate3d{instance=~"jupyterhub|odh-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate3d{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
           for: 3h
           labels:
             severity: warning

--- a/monitoring/rhods-dashboard-route.yaml
+++ b/monitoring/rhods-dashboard-route.yaml
@@ -2,8 +2,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
-    app: odh-dashboard
-  name: odh-dashboard
+    app: rhods-dashboard
+  name: rhods-dashboard
   namespace: redhat-ods-applications
 spec:
   port:
@@ -13,5 +13,5 @@ spec:
     termination: edge
   to:
     kind: Service
-    name: odh-dashboard
+    name: rhods-dashboard
   wildcardPolicy: None


### PR DESCRIPTION
To make sure user facing applications and urls have the RHODS branding, this change updates all k8s objects that reference "odh-dashboard" to "rhods-dashboard"

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>