### PR TITLE
Remove OpenShift pod restarting alert

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -496,16 +496,6 @@ data:
 
   alerting.rules: |
     groups:
-      - name: Pod Restarts
-        interval: 1m
-        rules:
-          - alert: An OpenShift pod has just restarted
-            expr: sum(delta(kube_pod_container_status_restarts_total{namespace="rhods-notebooks", pod!~"jupyterhub-nb-.*"}[5m])) by (namespace, pod) > 0
-            for: 5m
-            annotations:
-              summary: An OpenShift pod has just been restarted.
-              action: Check {{ $labels.kubernetes_pod_name }} pod in {{ $labels.kubernetes_namespace}} namespace to determine why the pod is restarting.
-              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
 
       - name: DeadManSnitch
         interval: 1m


### PR DESCRIPTION
Signed-off-by: Anish Asthana <anishasthana1@gmail.com>

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1832
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
