### PR TITLE
Disable JupyterHub DB monitoring

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -126,8 +126,6 @@ if [ "$deploy_on_osd" -eq 0 ]; then
     fi
   done
 
-  oc apply -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-db-probe/jupyterhub-db-probe-osd.yaml
-
 else
   # Not on OpenShift Dedicated, deploy local
   ODH_MANIFESTS="opendatahub.yaml"
@@ -136,11 +134,8 @@ else
   export jupyterhub_postgresql_password=$(openssl rand -hex 32)
   sed -i "s/<jupyterhub_postgresql_password>/$jupyterhub_postgresql_password/g" jupyterhub/jupyterhub-database-password.yaml
   oc create -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-database-password.yaml || echo "INFO: Jupyterhub Password already exist."
-  oc apply -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-db-probe/jupyterhub-db-probe-ocp.yaml
 
 fi
-
-oc apply -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-db-probe/jupyterhub-db-probe-svc.yaml
 
 oc apply -n ${ODH_PROJECT} -f ${ODH_MANIFESTS}
 if [ $? -ne 0 ]; then

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -435,44 +435,6 @@ data:
             instance: rhods-dashboard
           record: probe_success:burnrate6h
 
-      - name: SLOs - JupyterHub DB
-        rules:
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[1d])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate1d
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[1h])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate1h
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[2h])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate2h
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[30m])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate30m
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[3d])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate3d
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[5m])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate5m
-        - expr: |
-            1 - avg_over_time(jupyterhub_db_probe_success[6h])
-          labels:
-            instance: jupyterhub-db
-          record: probe_success:burnrate6h
-
       - name: SLOs - RHODS Operator
         interval: 15m
         rules:
@@ -778,25 +740,6 @@ data:
           regex: (.+):(\d+)
           target_label: __address__
           replacement: ${1}:8383
-
-    - job_name: "Jupyterhub DB Metrics"
-      honor_labels: true
-      scheme: http
-      metrics_path: /
-      kubernetes_sd_configs:
-        - role: endpoints
-          namespaces:
-            names:
-              - redhat-ods-applications
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(jupyterhub-db-probe)$
-          target_label: kubernetes_name
-          action: keep
-        - source_labels: [__address__]
-          regex: (.+):(\d+)
-          target_label: __address__
-          replacement: ${1}:8080
 
     alerting:
       alertmanagers:


### PR DESCRIPTION
This commit includes changes that removes database probe and monitoring rules
from prometheus scape and alert configs for JH DB.
Jira Issue : https://issues.redhat.com/browse/RHODS-1906

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
