### PR TITLE
update the tensorflow notebook build from tag nb-4

### DIFF
--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -105,7 +105,7 @@ items:
     tags:
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8.6"},{"name":"TensorFlow","version":"2.4.1"}]'
-        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.4.1"},{"name":"Tensorboard","version":"2.6.0"},{"name":"Boto3","version":"1.17.11"},{"name":"Kafka-Python","version":"2.0.2"},{"name":"Matplotlib","version":"3.4.1"},{"name":"Numpy","version":"1.19.2"},{"name":"Pandas","version":"1.2.4"},{"name":"Scikit-learn","version":"0.24.1"},{"name":"Scipy","version":"1.6.2"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.4.1"},{"name":"Tensorboard","version":"2.4.1"},{"name":"Boto3","version":"1.17.11"},{"name":"Kafka-Python","version":"2.0.2"},{"name":"Matplotlib","version":"3.4.1"},{"name":"Numpy","version":"1.19.2"},{"name":"Pandas","version":"1.2.4"},{"name":"Scikit-learn","version":"0.24.1"},{"name":"Scipy","version":"1.6.2"}]'
       name: "py3.8-cuda-11.0.3"
       referencePolicy:
         type: Local
@@ -371,7 +371,7 @@ items:
       type: Git
       git:
         uri: 'https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook'
-        ref: nb-3
+        ref: nb-4
     triggers:
       - type: ImageChange
         imageChange: {}


### PR DESCRIPTION
update the tensorflow notebook build from tag nb-4
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

This would relate to the same version listed on the attached jira issue.
Testing: It could be tested by viewing the tooltip of tensorflow-gpu and pip list of version inside the notebook.

Depends-On: https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook/pull/6

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1803
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
