### PR TITLE
Fix tls termination setting for rhods dashboard

### DIFF
--- a/monitoring/rhods-dashboard-route.yaml
+++ b/monitoring/rhods-dashboard-route.yaml
@@ -10,7 +10,7 @@ spec:
     targetPort: 8443
   tls:
     insecureEdgeTerminationPolicy: Redirect
-    termination: edge
+    termination: Reencrypt
   to:
     kind: Service
     name: rhods-dashboard


### PR DESCRIPTION
This is necessary to work with the authentication overlay for rhods
dashboard. See https://github.com/red-hat-data-services/odh-manifests/blob/master/odh-dashboard/overlays/authentication/route.yaml#L6

This addresses https://issues.redhat.com/browse/RHODS-1949

To test this:
1) Deploy RHODS
2) Run a curl of the RHODS dashboard in a while loop or with watch or something like that
3) From main, oc apply monitoring/rhods-dashboard-route.yaml
4) You should see the curl start to fail with a 400 status code
5) oc apply the monitoring/rhods-dashboard-route.yaml file from this change
6) The curl will start to succeed

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
