### PR TITLE
Allow MTSRE to reach Grafana via port-forwarding

### DIFF
--- a/monitoring/grafana/grafana-secrets.yaml
+++ b/monitoring/grafana/grafana-secrets.yaml
@@ -5,6 +5,10 @@ stringData:
     [auth]
     disable_login_form = true
     disable_signout_menu = true
+    [auth.anonymous]
+    enabled = true
+    # Role for unauthenticated users, other valid values are `Editor` and `Admin`
+    org_role = Viewer
     [auth.basic]
     enabled = false
     [auth.proxy]


### PR DESCRIPTION
Signed-off-by: Anish Asthana <anishasthana1@gmail.com>

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1991
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

To test this PR, do the following:
1) Access the Prometheus, Alertmanager, and Grafana routes. You should be able to reach them after authenticating past oauth-proxy. Dashboards will show up as they previously have, metrics and alerts will be the same.
2) From your terminal, while logged in on the cluster and on the `redhat-ods-monitoring` namespace follow these steps:

3) Run `oc -n redhat-ods-monitoring port-forward $(oc get pods -n redhat-ods-monitoring | grep grafana | head -1 | awk '{print $1}') 3001`, open private browsing window, go to `localhost:3001`, and view grafana dashboards without needing to authenticate via proxy.
3) Run `oc -n redhat-ods-monitoring  port-forward $(oc get pods -n redhat-ods-monitoring | grep prometheus | awk '{print $1}') 9090`, open private browsing window, go to `localhost:9090`, and view prometheus metrics without needing to authenticate via proxy.
3) Run `oc -n redhat-ods-monitoring  port-forward $(oc get pods -n redhat-ods-monitoring | grep prometheus | awk '{print $1}') 9093`, open private browsing window, go to `localhost:9093`, and view alerts without needing to authenticate via proxy.