### PR TITLE
Enable grafana port-forward.

### DIFF
--- a/monitoring/grafana/grafana-secrets.yaml
+++ b/monitoring/grafana/grafana-secrets.yaml
@@ -7,6 +7,9 @@ stringData:
     disable_signout_menu = true
     [auth.basic]
     enabled = false
+    [auth.anonymous]
+    enabled = true
+    org_role = Viewer
     [auth.proxy]
     auto_sign_up = true
     enabled = true


### PR DESCRIPTION
Enable grafana port-forwarding from inside the cluster. This is a request by MTSRE so we can bypass oauth as otherwise we won't have access to grafana inside customer clusters.

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): https://issues.redhat.com/browse/MTSRE-245
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
