### PR TITLE
Allow deployer to detect the need to recreate buildchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
+ARG builddate="unknown"
+ARG version="unknown"
+ARG vcs="unknown"
+
 ENV TMPDIR /tmp
 ENV HOME /home/deployer
+ENV RHODS_VERSION ${version}
 
 RUN microdnf update -y && \
     microdnf install -y \
@@ -19,6 +24,7 @@ RUN tar -C /usr/local/bin -xvf $TMPDIR/oc.tar.gz && \
     mkdir -p $HOME
 
 COPY deploy.sh $HOME
+COPY buildchain.sh $HOME
 COPY opendatahub.yaml $HOME
 COPY opendatahub-osd.yaml $HOME
 COPY rhods-monitoring.yaml $HOME
@@ -33,6 +39,7 @@ ADD network $HOME/network
 ADD cloud-resource-operator $HOME/cloud-resource-operator
 
 RUN chmod 755 $HOME/deploy.sh && \
+    chmod 755 $HOME/buildchain.sh && \
     chmod 644 $HOME/opendatahub.yaml && \
     chmod 644 $HOME/opendatahub-osd.yaml && \
     chmod 644 $HOME/rhods-monitoring.yaml && \
@@ -46,9 +53,16 @@ RUN chmod 755 $HOME/deploy.sh && \
     chown 1001:0 -R $HOME &&\
     chmod ug+rwx -R $HOME
 
-ARG builddate="(unknown)"
-ARG version="(unknown)"
-ARG vcs="(unknown)"
+# Generate the checksum before we modify the manifest to be version specific.
+# This checksum will be deployed in a configmap in a running deployment and so
+# if the content other than the rhods/buildchain label value changes, the
+# checksum will match
+RUN sha256sum $HOME/jupyterhub/cuda-11.0.3/manifests.yaml > $HOME/manifest-checksum
+
+# Update the labels with the specific version value
+RUN sed -i 's,rhods/buildchain:.*,rhods/buildchain: cuda-'"${version}"',g' \
+       $HOME/jupyterhub/cuda-11.0.3/manifests.yaml
+
 
 LABEL org.label-schema.build-date="$builddate" \
       org.label-schema.description="Pod to deploy the CR for Open Data Hub" \

--- a/buildchain.sh
+++ b/buildchain.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+ODH_PROJECT=${ODH_CR_NAMESPACE:-"redhat-ods-applications"}
+checksum=false
+version=false
+
+res=$(oc get cm rhods-buildchain -n $ODH_PROJECT)
+if [ "$?" -eq 0 ]; then
+    # See if the version matches
+    vers=$(oc get cm rhods-buildchain -n $ODH_PROJECT -o jsonpath='{.data.rhods-version}')
+    if [ "$vers" != "$RHODS_VERSION" ]; then
+        # The fact that the version is different doesn't necessarily mean
+        # that the checksum is different ...
+        version=true
+        echo rhods-buildchain version does not match
+        echo "    found: $vers"
+        echo "    current: $RHODS_VERSION"
+    else
+        echo rhods-buildchain version matches
+    fi
+    cs=$(oc get cm rhods-buildchain -n $ODH_PROJECT -o jsonpath='{.data.manifest-checksum}')
+    read line < $HOME/manifest-checksum
+    if [ "$cs" != "$line" ]; then
+        checksum=true
+        echo rhods-buildchain checksum does not match
+        echo "    found: $cs"
+        echo "    current: $line"
+    else
+        echo rhods-buildchain checksum matches
+    fi
+else
+    echo rhods-buildchain configmap missing
+    version=true
+    checksum=true
+fi
+
+if [ "$checksum" == "true" ]; then
+    echo recreating the runtime buildchain
+    oc delete buildconfig -l rhods/buildchain -n $ODH_PROJECT
+    oc delete is -l rhods/buildchain -n $ODH_PROJECT
+    oc apply -f $HOME/jupyterhub/cuda-11.0.3/manifests.yaml -n $ODH_PROJECT
+
+elif [ "$version" == "true" ]; then
+    echo relabeling build objects with "$RHODS_VERSION"
+
+    bc=($(oc get buildconfig -l rhods/buildchain -n $ODH_PROJECT -o jsonpath=' {range .items [*]} {.metadata.name}'))
+    for name in ${bc[*]}; do
+        oc label buildconfig -n $ODH_PROJECT "$name" rhods/buildchain=cuda-"$RHODS_VERSION" --overwrite=true
+    done
+
+    is=($(oc get imagestream -l rhods/buildchain -n $ODH_PROJECT -o jsonpath=' {range .items [*]} {.metadata.name}'))
+    for name in ${is[*]}; do
+        oc label imagestream -n $ODH_PROJECT "$name" rhods/buildchain=cuda-"$RHODS_VERSION" --overwrite=true
+    done
+fi
+
+# We always do this, to make sure that checksum and version match
+# whether we're creating it, modifying it, or making no net change
+if [ "$checksum" == "true" -o "$version" == "true" ]; then
+    echo updating rhods-buildchain configmap
+    oc create --save-config cm rhods-buildchain \
+       --from-file=$HOME/manifest-checksum \
+       --from-literal=rhods-version="$RHODS_VERSION" \
+       --dry-run=client -o yaml -n $ODH_PROJECT | oc apply -f -
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -99,7 +99,9 @@ export jupyterhub_prometheus_api_token=$(openssl rand -hex 32)
 sed -i "s/<jupyterhub_prometheus_api_token>/$jupyterhub_prometheus_api_token/g" monitoring/jupyterhub-prometheus-token-secrets.yaml
 oc create -n ${ODH_PROJECT} -f monitoring/jupyterhub-prometheus-token-secrets.yaml || echo "INFO: Jupyterhub scrape token already exist."
 
-oc apply -n $ODH_PROJECT -f jupyterhub/cuda-11.0.3/manifests.yaml
+# Create the runtime buildchain if the rhods-buildchain configmap is missing,
+# otherwise recreate it if the stored hecksum does not match
+$HOME/buildchain.sh
 
 # Check if the installation target is OSD to determine the deployment manifest path
 deploy_on_osd=0

--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -4,6 +4,8 @@ items:
   apiVersion: image.openshift.io/v1
   metadata:
     name: "nvidia-cuda-11.0.3"
+    labels:
+      rhods/buildchain: cuda
   spec:
     lookupPolicy:
       local: true
@@ -19,6 +21,8 @@ items:
   apiVersion: image.openshift.io/v1
   metadata:
     name: "11.0.3-cuda-s2i-core-ubi8"
+    labels:
+      rhods/buildchain: cuda
   spec:
     lookupPolicy:
       local: true
@@ -31,6 +35,8 @@ items:
   apiVersion: image.openshift.io/v1
   metadata:
     name: "11.0.3-cuda-s2i-base-ubi8"
+    labels:
+      rhods/buildchain: cuda
   spec:
     lookupPolicy:
       local: true
@@ -45,6 +51,8 @@ items:
   apiVersion: image.openshift.io/v1
   metadata:
     name: "11.0.3-cuda-s2i-py38-ubi8"
+    labels:
+      rhods/buildchain: cuda
   spec:
     lookupPolicy:
       local: true
@@ -57,6 +65,8 @@ items:
   apiVersion: image.openshift.io/v1
   metadata:
     name: "11.0.3-cuda-s2i-thoth-ubi8-py38"
+    labels:
+      rhods/buildchain: cuda
   spec:
     lookupPolicy:
       local: true
@@ -71,6 +81,7 @@ items:
     labels:
       component.opendatahub.io/name: jupyterhub
       opendatahub.io/component: 'true'
+      rhods/buildchain: cuda
     annotations:
       opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-minimal-notebook"
       opendatahub.io/notebook-image-name: "CUDA"
@@ -93,6 +104,7 @@ items:
       component.opendatahub.io/name: jupyterhub
       opendatahub.io/component: 'true'
       opendatahub.io/notebook-image: 'true'
+      rhods/buildchain: cuda
     annotations:
       opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook"
       opendatahub.io/notebook-image-name: "TensorFlow"
@@ -116,6 +128,7 @@ items:
       component.opendatahub.io/name: jupyterhub
       opendatahub.io/component: 'true'
       opendatahub.io/notebook-image: 'true'
+      rhods/buildchain: cuda
     annotations:
       opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-pytorch-notebook"
       opendatahub.io/notebook-image-name: "PyTorch"
@@ -139,6 +152,7 @@ items:
     name: "11.0.3-cuda-s2i-core-ubi8"
     labels:
       opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:
@@ -180,6 +194,7 @@ items:
     name: "11.0.3-cuda-s2i-base-ubi8"
     labels:
       opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:
@@ -221,6 +236,7 @@ items:
     name: "11.0.3-cuda-s2i-py38-ubi8"
     labels:
       opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:
@@ -262,6 +278,7 @@ items:
     name: "11.0.3-cuda-s2i-thoth-ubi8-py38"
     labels:
       opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:
@@ -303,6 +320,7 @@ items:
     labels:
       opendatahub.io/build_type: "notebook_image"
       opendatahub.io/notebook-name: "CUDA"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:
@@ -344,6 +362,7 @@ items:
     labels:
       opendatahub.io/build_type: "notebook_image"
       opendatahub.io/notebook-name: "TensorFlow"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:
@@ -383,6 +402,7 @@ items:
     labels:
       opendatahub.io/build_type: "notebook_image"
       opendatahub.io/notebook-name: "PyTorch"
+      rhods/buildchain: cuda
   spec:
     nodeSelector: null
     output:


### PR DESCRIPTION
This so that the deployer can recognize them at runtime
and take appropriate action on upgrades.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1990
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
