### PR TITLE
Updated RHODS alerts to point to documentation

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -556,7 +556,7 @@ data:
         - alert: RHODS Route Error Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(haproxy_backend_http_responses_total:burnrate5m{route=~"jupyterhub|rhods-dashboard"}) by (route) > (14.40 * (1-0.98000))
@@ -568,7 +568,7 @@ data:
         - alert: RHODS Route Error Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(haproxy_backend_http_responses_total:burnrate30m{route=~"jupyterhub|rhods-dashboard"}) by (route) > (6.00 * (1-0.98000))
@@ -580,7 +580,7 @@ data:
         - alert: RHODS Route Error Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(haproxy_backend_http_responses_total:burnrate2h{route=~"jupyterhub|rhods-dashboard"}) by (route) > (3.00 * (1-0.98000))
@@ -592,7 +592,7 @@ data:
         - alert: RHODS Route Error Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(haproxy_backend_http_responses_total:burnrate6h{route=~"jupyterhub|rhods-dashboard"}) by (route) > (1.00 * (1-0.98000))
@@ -630,7 +630,7 @@ data:
         - alert: RHODS Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(probe_success:burnrate5m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
@@ -642,7 +642,7 @@ data:
         - alert: RHODS Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(probe_success:burnrate30m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
@@ -654,7 +654,7 @@ data:
         - alert: RHODS Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(probe_success:burnrate2h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
@@ -666,7 +666,7 @@ data:
         - alert: RHODS Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
             sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
@@ -705,7 +705,7 @@ data:
         - alert: JupyterHub image builds are failing
           annotations:
             message: 'A JupyterHub image build is in a failed state.'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/spawner-greyed-images.md"
             build: "{{ $labels.buildconfig }}"
             summary: JupyterHub image builds are failing
           expr: openshift_build_status_phase_total{build_phase=~"error|failed", namespace="redhat-ods-applications"} == 1


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-1958
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## Testing steps

- Check that the links are poitint to the correct Runbook.