### PR TITLE
Alert only on new builds that are failing

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -708,10 +708,11 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
             build: "{{ $labels.buildconfig }}"
             summary: JupyterHub image builds are failing
-          expr: openshift_build_status_phase_total{build_phase=~"error|failed", namespace="redhat-ods-applications"} == 1
-          for: 15m
+          expr: sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed", namespace="redhat-ods-applications"}) > sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed", namespace="redhat-ods-applications"} offset 10m)
+          for: 5m
           labels:
-            severity: critical
+            severity: warning
+
 
   prometheus.yml: |
     rule_files:


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2051
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
