### PR TITLE
Updating registry.redhat.io/openshift4/ose-oauth-proxy to use the :v4.8 tag to pin to latest known-working image

### DIFF
--- a/monitoring/grafana/grafana.yaml
+++ b/monitoring/grafana/grafana.yaml
@@ -150,7 +150,7 @@ spec:
             - '-skip-auth-regex=^/metrics'
           env:
             - name: redhat-ods-monitoring
-          image: registry.redhat.io/openshift4/ose-oauth-proxy
+          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
           imagePullPolicy: IfNotPresent
           name: auth-proxy
           ports:

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -51,7 +51,7 @@ spec:
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - -client-id=system:serviceaccount:redhat-ods-monitoring:prometheus
         - -skip-auth-regex=^/metrics
-        image: registry.redhat.io/openshift4/ose-oauth-proxy
+        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
         ports:
         - containerPort: 9091
           name: https
@@ -162,7 +162,7 @@ spec:
         - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - -client-id=system:serviceaccount:redhat-ods-monitoring:prometheus
         - -skip-auth-regex=^/metrics
-        image: registry.redhat.io/openshift4/ose-oauth-proxy
+        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
         imagePullPolicy: Always
         ports:
         - containerPort: 10443


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Non-cherry-pick since upstream does it differently
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2105
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
