### PR TITLE
Add relabeling of build objects in buildchain.sh

### DIFF
--- a/buildchain.sh
+++ b/buildchain.sh
@@ -48,6 +48,11 @@ elif [ "$version" == "true" ]; then
         oc label buildconfig -n $ODH_PROJECT "$name" rhods/buildchain=cuda-"$RHODS_VERSION" --overwrite=true
     done
 
+    bu=($(oc get build -l rhods/buildchain -n $ODH_PROJECT -o jsonpath=' {range .items [*]} {.metadata.name}'))
+    for name in ${bu[*]}; do
+        oc label build -n $ODH_PROJECT "$name" rhods/buildchain=cuda-"$RHODS_VERSION" --overwrite=true
+    done
+
     is=($(oc get imagestream -l rhods/buildchain -n $ODH_PROJECT -o jsonpath=' {range .items [*]} {.metadata.name}'))
     for name in ${is[*]}; do
         oc label imagestream -n $ODH_PROJECT "$name" rhods/buildchain=cuda-"$RHODS_VERSION" --overwrite=true


### PR DESCRIPTION
When the version doesn't match but the checksum does, build objects
should be relabeled with the current version along with buildconfigs
and imagestreams (which are already happening).

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1990
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
