### PR TITLE
Change imagestream tags to py3.8 for generic and minimal notebooks

### DIFF
--- a/buildchain.sh
+++ b/buildchain.sh
@@ -4,6 +4,7 @@ ODH_PROJECT=${ODH_CR_NAMESPACE:-"redhat-ods-applications"}
 checksum=false
 version=false
 
+# Figure out if the RHODS version has changed or the buildchain manifest checksum
 res=$(oc get cm rhods-buildchain -n $ODH_PROJECT)
 if [ "$?" -eq 0 ]; then
     # See if the version matches
@@ -34,6 +35,7 @@ else
     checksum=true
 fi
 
+# Handle relabeling or recreating the buildchain objects
 if [ "$checksum" == "true" ]; then
     echo recreating the runtime buildchain
     oc delete buildconfig -l rhods/buildchain -n $ODH_PROJECT

--- a/deploy.sh
+++ b/deploy.sh
@@ -103,6 +103,23 @@ oc create -n ${ODH_PROJECT} -f monitoring/jupyterhub-prometheus-token-secrets.ya
 # otherwise recreate it if the stored hecksum does not match
 $HOME/buildchain.sh
 
+# As a one-time repair, move the tags for generic and minimal to py3.8 instead of v0.0.5 and v0.0.15
+set +e
+res=$(oc tag s2i-minimal-notebook:v0.0.15 s2i-minimal-notebook:py3.8 -n ${ODH_PROJECT} &>/dev/null)
+if [ "$?" -eq 0 ]; then
+    # tagging v0.0.15 to py3.8 worked, which means the v0.0.15 tag existed :) Remove it
+    echo Tagged s2i-minimal-notebook:v0.0.15 to s2i-minimal-notebook:py3.8
+    oc tag -d s2i-minimal-notebook:v0.0.15 -n ${ODH_PROJECT}
+fi
+
+res=$(oc tag s2i-generic-data-science-notebook:v0.0.5 s2i-generic-data-science-notebook:py3.8 -n ${ODH_PROJECT} &>/dev/null)
+if [ "$?" -eq 0 ]; then
+    # tagging v0.0.5 to py3.8 worked, which means the v0.0.5 tag existed :) Remove it
+    echo Tagged s2i-generic-data-science-notebook:v0.0.5 to s2i-generic-data-science-notebook:py3.8
+    oc tag -d s2i-generic-data-science-notebook:v0.0.5 -n ${ODH_PROJECT}
+fi
+set -e
+
 # Check if the installation target is OSD to determine the deployment manifest path
 deploy_on_osd=0
 oc get group dedicated-admins &> /dev/null || deploy_on_osd=1


### PR DESCRIPTION
Change imagestream tags for the generic data science notebook and minimal notebook to py3.8 to create a stable, meaningful tag following the pattern of "py3.8-cuda-11.0.3" on the runtime buildchain. This tag based on the Python version will allow us to update the actual image referenced by the imagestream without having the image version explicitly in the tag, which leads to tag management issues on upgrades.

As a one-time fix, the deployer will retag existing v0.0.5 and v0.0.15 images with the py3.8 tag and then delete the v0.0.5 and v0.0.15 tags.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-973
- [x] The Jira story is acked 
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
