### PR TITLE
Stop Dev clusters from paging SRE

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -247,6 +247,14 @@ then
   sed -i "s/redhat-openshift-alert@devshift.net/redhat-openshift-alert@rhmw.io/g" monitoring/prometheus/prometheus.yaml
 fi
 
+if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"aisrhods".* ]]
+then
+  echo "Cluster is for RHODS engineering or test purposes. Disabling SRE alerting."
+  sed -i "s/receiver: PagerDuty/receiver: developer-mails/g" monitoring/prometheus/prometheus.yaml
+else
+  echo "Cluster is not for RHODS engineering or test purposes."
+fi
+
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus.yaml
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/grafana/grafana-sa.yaml
 

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -1493,7 +1493,7 @@ data:
     receivers:
     - name: 'developer-mails'
       email_configs:
-      - to: 'test-123@foo.com'
+      - to: 'test-123@redhat.com'
         send_resolved: true
 
     - name: 'user-notifications'


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2129
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
