### PR TITLE
Add oauth-proxy authentication to BB exporter pod

### DIFF
--- a/monitoring/prometheus/blackbox-exporter-common.yaml
+++ b/monitoring/prometheus/blackbox-exporter-common.yaml
@@ -7,10 +7,10 @@ metadata:
   name: blackbox-exporter
 spec:
   ports:
-  - name: 9115-tcp
-    port: 9115
+  - name: 9114-tcp
+    port: 9114
     protocol: TCP
-    targetPort: 9115
+    targetPort: 9114
   selector:
     deployment: blackbox-exporter
 
@@ -35,6 +35,15 @@ spec:
       - name: config-volume
         configMap:
           name: blackbox
+      - name: prometheus-tls
+        secret:
+          defaultMode: 420
+          secretName: prometheus-tls
+      - name: prometheus-proxy
+        secret:
+          defaultMode: 420
+          secretName: prometheus-proxy
+      serviceAccountName: prometheus
       initContainers:
         - name: wait-for-deployment
           image: 'registry.access.redhat.com/ubi8/ubi-minimal:8.4-208'
@@ -50,6 +59,64 @@ spec:
             - '-c'
             - for i in `seq 1 230`; do sleep 10; echo "Waiting for rhods-dashboard service to become available..."; if curl -s -k https://rhods-dashboard.redhat-ods-applications.svc:8443; then exit 0; fi; done; exit 1
       containers:
+      - name: oauth-proxy
+        args:
+        - -provider=openshift
+        - -https-address=:9114
+        - -http-address=
+        - -email-domain=*
+        - -upstream=http://localhost:9115
+        - -openshift-service-account=prometheus
+        - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "redhat-ods-monitoring",
+          "namespace": "redhat-ods-monitoring"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
+          "name": "redhat-ods-monitoring", "namespace": "redhat-ods-monitoring"}}'
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - -cookie-secret-file=/etc/proxy/secrets/session_secret
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -client-id=system:serviceaccount:redhat-ods-monitoring:prometheus
+        - -skip-auth-regex=^/metrics
+        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        ports:
+        - containerPort: 9114
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 9114
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 9114
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: prometheus-tls
+          readOnly: false
+        - mountPath: /etc/proxy/secrets
+          name: prometheus-proxy
+          readOnly: false
       - image: quay.io/integreatly/prometheus-blackbox-exporter:v0.19.0
         name: blackbox-exporter
         args:

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -793,8 +793,13 @@ data:
     - job_name: 'user_facing_endpoints_status'
       scrape_interval: 10s
       metrics_path: /probe
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
       params:
         module: [http_2xx]
+      authorization:
+        credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
       static_configs:
       - targets:
         - <jupyterhub_host>
@@ -805,7 +810,7 @@ data:
       - source_labels: [__param_target]
         target_label: instance
       - target_label: __address__
-        replacement: blackbox-exporter.redhat-ods-monitoring.svc.cluster.local:9115
+        replacement: blackbox-exporter.redhat-ods-monitoring.svc.cluster.local:9114
 
     - job_name: 'RHODS Metrics'
       honor_labels: true


### PR DESCRIPTION
This blackbox exporter can potentially be used to execute http queries
against any arbitrary endpoint. This change adds the oauth proxy in
front of the blackbox exporter service so that only authorized users can
interact with this service. It also configures the prometheus scrape
jobs which use the blackbox exporter to authenticate to the blackbox
exporter using an OpenShift service account's bearer token.

**JIRA issue**: https://issues.redhat.com/browse/RHODS-734 

### Testing Instructions:

* Deploy RHODS from before this change
* Confirm that the blackbox exporter pod has only one container (the application pod)
* Navigate to the prometheus route in the redhat-ods-monitoring namespace
* Click on the "Targets" item under the "status" dropdown at the top of the prometheus windoe
* Confirm that all of the targets under "user_facing_endpoints_status" (at the bottom) are listed as up
* Deploy this change
* Confirm that the blackbox exporter pod now has 2 containers (one for the application, one for auth)
* Confirm in prometheus that the target is still up
* Open a terminal in the prometheus pod. Run the following command and verify that you get a response prompting you to log in with OpenShift:
```
curl --insecure https://blackbox-exporter.redhat-ods-monitoring.svc.cluster.local:9114/probe?module=http_2xx&target=jupyterhub-redhat-ods-applications.apps.acorvin.dev.datahub.redhat.com
```

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-734 
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
