### PR TITLE
Restore minimal-gpu notebook as JH notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,11 @@ RUN chmod 755 $HOME/deploy.sh && \
 # This checksum will be deployed in a configmap in a running deployment and so
 # if the content other than the rhods/buildchain label value changes, the
 # checksum will match
-RUN sha256sum $HOME/jupyterhub/cuda-11.0.3/manifests.yaml > $HOME/manifest-checksum
+RUN sha256sum $HOME/jupyterhub/cuda-11.4.2/manifests.yaml > $HOME/manifest-checksum
 
 # Update the labels with the specific version value
 RUN sed -i 's,rhods/buildchain:.*,rhods/buildchain: cuda-'"${version}"',g' \
-       $HOME/jupyterhub/cuda-11.0.3/manifests.yaml
+       $HOME/jupyterhub/cuda-11.4.2/manifests.yaml
 
 
 LABEL org.label-schema.build-date="$builddate" \

--- a/buildchain.sh
+++ b/buildchain.sh
@@ -67,7 +67,7 @@ if [ "$checksum" == "true" ]; then
     echo recreating the runtime buildchain
     oc delete buildconfig -l rhods/buildchain -n $ODH_PROJECT
     oc delete is -l rhods/buildchain -n $ODH_PROJECT
-    oc apply -f $HOME/jupyterhub/cuda-11.0.3/manifests.yaml -n $ODH_PROJECT
+    oc apply -f $HOME/jupyterhub/cuda-11.4.2/manifests.yaml -n $ODH_PROJECT
 
 elif [ "$version" == "true" ]; then
     echo relabeling build objects with "$RHODS_VERSION"

--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -81,11 +81,13 @@ items:
     labels:
       component.opendatahub.io/name: jupyterhub
       opendatahub.io/component: 'true'
+      opendatahub.io/notebook-image: 'true'
       rhods/buildchain: cuda
     annotations:
       opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-minimal-notebook"
       opendatahub.io/notebook-image-name: "CUDA"
       opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
+      opendatahub.io/notebook-image-order: "30"
     name: "minimal-gpu"
   spec:
     lookupPolicy:
@@ -109,14 +111,14 @@ items:
       opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook"
       opendatahub.io/notebook-image-name: "TensorFlow"
       opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-      opendatahub.io/notebook-image-order: "40"
+      opendatahub.io/notebook-image-order: "50"
     name: "tensorflow"
   spec:
     lookupPolicy:
       local: true
     tags:
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"},{"name":"CUDA","version":"11.0"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
       name: "py3.8-cuda-11.0.3-1"
       referencePolicy:
@@ -133,14 +135,14 @@ items:
       opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-pytorch-notebook"
       opendatahub.io/notebook-image-name: "PyTorch"
       opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
-      opendatahub.io/notebook-image-order: "30"
+      opendatahub.io/notebook-image-order: "40"
     name: "pytorch"
   spec:
     lookupPolicy:
       local: true
     tags:
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"},{"name":"CUDA","version":"11.0"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"1.15"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
       name: "py3.8-cuda-11.0.3-1"
       referencePolicy:

--- a/jupyterhub/cuda-11.4.2/README.md
+++ b/jupyterhub/cuda-11.4.2/README.md
@@ -1,0 +1,56 @@
+If the source reference for pytorch or tensorflow changes
+or the ultimate base image changes, you MUST increment the output
+tags for pytorch and/or tensorflow.
+
+(Otherwise the tag may match an older image and the new images will not be used on an
+upgraded installation if the workers have the old image cached)
+
+The intermediate images between the base image and pytorch and tensorflow will always be
+re-pulled by the openshift builds, and so they can always use the default "latest" tag
+without causing a problem.
+
+The "-N" string at the end of the pytorch and tensorflow tags are an incrementing
+value that you can use to produce a new tag.
+
+For example (same applies to tensorflow):
+
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: s2i-pytorch-gpu-cuda-11.4.2-notebook
+    labels:
+      opendatahub.io/build_type: "notebook_image"
+      opendatahub.io/notebook-name: "PyTorch"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'pytorch:py3.8-cuda-11.4.2-1'   <<<<<<<<< This must be changed to pytorch:py3.8-cuda-11.4.2-2 ..... (read on) ...
+    resources:
+      limits:
+        cpu: "4"
+        memory: 8Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'minimal-gpu:py3.8-cuda-11.4.2'
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-pytorch-notebook'
+        ref: nb-4                                                                <<<<<<<<<<< ... if this tag changes or the ultimate base image changes
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly

--- a/jupyterhub/cuda-11.4.2/manifests.yaml
+++ b/jupyterhub/cuda-11.4.2/manifests.yaml
@@ -1,0 +1,441 @@
+apiVersion: v1
+items:
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: "nvidia-cuda-11.4.2"
+    labels:
+      rhods/buildchain: cuda
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: 'nvcr.io/nvidia/cuda:11.4.2-cudnn8-devel-ubi8'
+      importPolicy: {}
+      referencePolicy:
+        type: Source
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-core-ubi8"
+    labels:
+      rhods/buildchain: cuda
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+      - name: latest
+        importPolicy: {}
+        referencePolicy:
+          type: Local
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-base-ubi8"
+    labels:
+      rhods/buildchain: cuda
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+      - name: latest
+        annotations: null
+        generation: 1
+        importPolicy: {}
+        referencePolicy:
+          type: Local
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-py38-ubi8"
+    labels:
+      rhods/buildchain: cuda
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+      - name: latest
+        importPolicy: {}
+        referencePolicy:
+          type: Local
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-thoth-ubi8-py38"
+    labels:
+      rhods/buildchain: cuda
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+      - name: latest
+        importPolicy: {}
+        referencePolicy:
+          type: Local
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    labels:
+      component.opendatahub.io/name: jupyterhub
+      opendatahub.io/component: 'true'
+      opendatahub.io/notebook-image: 'true'
+      rhods/buildchain: cuda
+    annotations:
+      opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-minimal-notebook"
+      opendatahub.io/notebook-image-name: "CUDA"
+      opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
+      opendatahub.io/notebook-image-order: "30"
+    name: "minimal-gpu"
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"CUDA","version":"11.4"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2.4"},{"name":"Notebook","version":"6.4"}]'
+      name: "py3.8-cuda-11.4.2"
+      referencePolicy:
+        type: Local
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    labels:
+      component.opendatahub.io/name: jupyterhub
+      opendatahub.io/component: 'true'
+      opendatahub.io/notebook-image: 'true'
+      rhods/buildchain: cuda
+    annotations:
+      opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook"
+      opendatahub.io/notebook-image-name: "TensorFlow"
+      opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+      opendatahub.io/notebook-image-order: "50"
+    name: "tensorflow"
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"},{"name":"CUDA","version":"11.4"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
+      name: "py3.8-cuda-11.4.2-1"
+      referencePolicy:
+        type: Local
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    labels:
+      component.opendatahub.io/name: jupyterhub
+      opendatahub.io/component: 'true'
+      opendatahub.io/notebook-image: 'true'
+      rhods/buildchain: cuda
+    annotations:
+      opendatahub.io/notebook-image-url: "https://github.com/red-hat-data-services/s2i-pytorch-notebook"
+      opendatahub.io/notebook-image-name: "PyTorch"
+      opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
+      opendatahub.io/notebook-image-order: "40"
+    name: "pytorch"
+  spec:
+    lookupPolicy:
+      local: true
+    tags:
+    - annotations:
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"},{"name":"CUDA","version":"11.4"}]'
+        opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"1.15"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
+      name: "py3.8-cuda-11.4.2-1"
+      referencePolicy:
+        type: Local
+
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-core-ubi8"
+    labels:
+      opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: '11.4.2-cuda-s2i-core-ubi8:latest'
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: "2"
+        memory: 4Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'nvidia-cuda-11.4.2:latest'
+        noCache: true
+        dockerfilePath: Dockerfile.rhel8
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-base-container'
+        ref: nb-2
+      contextDir: core
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-base-ubi8"
+    labels:
+      opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: '11.4.2-cuda-s2i-base-ubi8:latest'
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: "2"
+        memory: 4Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: '11.4.2-cuda-s2i-core-ubi8:latest'
+        noCache: true
+        dockerfilePath: Dockerfile.rhel8
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-base-container'
+        ref: nb-2
+      contextDir: base
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-py38-ubi8"
+    labels:
+      opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: '11.4.2-cuda-s2i-py38-ubi8:latest'
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: "2"
+        memory: 4Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: '11.4.2-cuda-s2i-base-ubi8:latest'
+        noCache: true
+        dockerfilePath: Dockerfile.rhel8
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-python-container'
+        ref: nb-1
+      contextDir: '3.8'
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: "11.4.2-cuda-s2i-thoth-ubi8-py38"
+    labels:
+      opendatahub.io/build_type: "base_image"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: '11.4.2-cuda-s2i-thoth-ubi8-py38:latest'
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: "2"
+        memory: 4Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: '11.4.2-cuda-s2i-py38-ubi8:latest'
+        noCache: true
+        dockerfilePath: ubi8-py38/Dockerfile
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-thoth'
+        ref: nb-2
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: s2i-minimal-gpu-cuda-11.4.2-notebook
+    labels:
+      opendatahub.io/build_type: "notebook_image"
+      opendatahub.io/notebook-name: "CUDA"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'minimal-gpu:py3.8-cuda-11.4.2'
+    resources:
+      limits:
+        cpu: "4"
+        memory: 8Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Docker
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: '11.4.2-cuda-s2i-thoth-ubi8-py38:latest'
+        noCache: true
+        dockerfilePath: Dockerfile
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-minimal-notebook'
+        ref: nb-6
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: s2i-tensorflow-gpu-cuda-11.4.2-notebook
+    labels:
+      opendatahub.io/build_type: "notebook_image"
+      opendatahub.io/notebook-name: "TensorFlow"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'tensorflow:py3.8-cuda-11.4.2-1'
+    resources:
+      limits:
+        cpu: "4"
+        memory: 8Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'minimal-gpu:py3.8-cuda-11.4.2'
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-tensorflow-gpu-notebook'
+        ref: nb-5
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: s2i-pytorch-gpu-cuda-11.4.2-notebook
+    labels:
+      opendatahub.io/build_type: "notebook_image"
+      opendatahub.io/notebook-name: "PyTorch"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'pytorch:py3.8-cuda-11.4.2-1'
+    resources:
+      limits:
+        cpu: "4"
+        memory: 8Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'minimal-gpu:py3.8-cuda-11.4.2'
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-pytorch-notebook'
+        ref: nb-4
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly
+kind: List
+metadata: {}


### PR DESCRIPTION
Restores the minimal-gpu notebook as a user selectable notebook and add
"CUDA Version" as an annotation for PyTorch and Tensorflow notebooks

**NOTE:** This change to CUDA only affects the base `nvidia/cuda` base image version.  The minimal, pytorch and tensorflow images will use the same package versions and source files.

Test Steps:
1. Confirm that the CUDA notebook is visible in the spawner, all cuda notebooks display the Cuda version and you can select 0 or more gpus
2. Spawn a cuda notebook with gpu > 0
3. Run `nvidia-smi` from the notebook pod or in a notebook `!nvidia-smi` and see that a GPU is available

You can check the notebook library can access the gpu via:
TensorFlow:
```python
import tensorflow as tf
print("Num GPUs Available: ", len(tf.config.list_physical_devices('GPU')))
```

PyTorch:
```python
import torch
torch.cuda.is_available() # True
```
Jira: RHODS-2315

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2315
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
