### PR TITLE
Delete tags for prebuilt images on upgrade

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -99,27 +99,6 @@ export jupyterhub_prometheus_api_token=$(openssl rand -hex 32)
 sed -i "s/<jupyterhub_prometheus_api_token>/$jupyterhub_prometheus_api_token/g" monitoring/jupyterhub-prometheus-token-secrets.yaml
 oc create -n ${ODH_PROJECT} -f monitoring/jupyterhub-prometheus-token-secrets.yaml || echo "INFO: Jupyterhub scrape token already exist."
 
-# Create the runtime buildchain if the rhods-buildchain configmap is missing,
-# otherwise recreate it if the stored hecksum does not match
-$HOME/buildchain.sh
-
-# As a one-time repair, move the tags for generic and minimal to py3.8 instead of v0.0.5 and v0.0.15
-set +e
-res=$(oc tag s2i-minimal-notebook:v0.0.15 s2i-minimal-notebook:py3.8 -n ${ODH_PROJECT} &>/dev/null)
-if [ "$?" -eq 0 ]; then
-    # tagging v0.0.15 to py3.8 worked, which means the v0.0.15 tag existed :) Remove it
-    echo Tagged s2i-minimal-notebook:v0.0.15 to s2i-minimal-notebook:py3.8
-    oc tag -d s2i-minimal-notebook:v0.0.15 -n ${ODH_PROJECT}
-fi
-
-res=$(oc tag s2i-generic-data-science-notebook:v0.0.5 s2i-generic-data-science-notebook:py3.8 -n ${ODH_PROJECT} &>/dev/null)
-if [ "$?" -eq 0 ]; then
-    # tagging v0.0.5 to py3.8 worked, which means the v0.0.5 tag existed :) Remove it
-    echo Tagged s2i-generic-data-science-notebook:v0.0.5 to s2i-generic-data-science-notebook:py3.8
-    oc tag -d s2i-generic-data-science-notebook:v0.0.5 -n ${ODH_PROJECT}
-fi
-set -e
-
 # Check if the installation target is OSD to determine the deployment manifest path
 deploy_on_osd=0
 oc get group dedicated-admins &> /dev/null || deploy_on_osd=1
@@ -329,3 +308,7 @@ fi
 
 # Add network policies
 oc apply -f network/
+
+# Create the runtime buildchain if the rhods-buildchain configmap is missing,
+# otherwise recreate it if the stored hecksum does not match
+$HOME/buildchain.sh


### PR DESCRIPTION
This change removes imagestream tags for prebuilt images
in the odh-deployer on a version upgrade. The operator
will create tags when it starts. This is to prevent the
accumulation of tags on multiple upgrades (the operator
will add a new tag, but not remove existing).

It also moves the buildchain.sh script to the end of the
init routine, so that the time to tag creation is as short
as possible.

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2364
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
