### PR TITLE
Bump tags for TensorFlow and PyTorch images

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -99,27 +99,6 @@ export jupyterhub_prometheus_api_token=$(openssl rand -hex 32)
 sed -i "s/<jupyterhub_prometheus_api_token>/$jupyterhub_prometheus_api_token/g" monitoring/jupyterhub-prometheus-token-secrets.yaml
 oc create -n ${ODH_PROJECT} -f monitoring/jupyterhub-prometheus-token-secrets.yaml || echo "INFO: Jupyterhub scrape token already exist."
 
-# Create the runtime buildchain if the rhods-buildchain configmap is missing,
-# otherwise recreate it if the stored hecksum does not match
-$HOME/buildchain.sh
-
-# As a one-time repair, move the tags for generic and minimal to py3.8 instead of v0.0.5 and v0.0.15
-set +e
-res=$(oc tag s2i-minimal-notebook:v0.0.15 s2i-minimal-notebook:py3.8 -n ${ODH_PROJECT} &>/dev/null)
-if [ "$?" -eq 0 ]; then
-    # tagging v0.0.15 to py3.8 worked, which means the v0.0.15 tag existed :) Remove it
-    echo Tagged s2i-minimal-notebook:v0.0.15 to s2i-minimal-notebook:py3.8
-    oc tag -d s2i-minimal-notebook:v0.0.15 -n ${ODH_PROJECT}
-fi
-
-res=$(oc tag s2i-generic-data-science-notebook:v0.0.5 s2i-generic-data-science-notebook:py3.8 -n ${ODH_PROJECT} &>/dev/null)
-if [ "$?" -eq 0 ]; then
-    # tagging v0.0.5 to py3.8 worked, which means the v0.0.5 tag existed :) Remove it
-    echo Tagged s2i-generic-data-science-notebook:v0.0.5 to s2i-generic-data-science-notebook:py3.8
-    oc tag -d s2i-generic-data-science-notebook:v0.0.5 -n ${ODH_PROJECT}
-fi
-set -e
-
 # Check if the installation target is OSD to determine the deployment manifest path
 deploy_on_osd=0
 oc get group dedicated-admins &> /dev/null || deploy_on_osd=1
@@ -329,3 +308,7 @@ fi
 
 # Add network policies
 oc apply -f network/
+
+# Create the runtime buildchain if the rhods-buildchain configmap is missing,
+# otherwise recreate it if the stored hecksum does not match
+$HOME/buildchain.sh

--- a/jupyterhub/cuda-11.0.3/README.md
+++ b/jupyterhub/cuda-11.0.3/README.md
@@ -1,0 +1,56 @@
+If the source reference for pytorch or tensorflow changes
+or the ultimate base image changes, you MUST increment the output
+tags for pytorch and/or tensorflow.
+
+(Otherwise the tag may match an older image and the new images will not be used on an
+upgraded installation if the workers have the old image cached)
+
+The intermediate images between the base image and pytorch and tensorflow will always be
+re-pulled by the openshift builds, and so they can always use the default "latest" tag
+without causing a problem.
+
+The "-N" string at the end of the pytorch and tensorflow tags are an incrementing
+value that you can use to produce a new tag.
+
+For example (same applies to tensorflow):
+
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    name: s2i-pytorch-gpu-cuda-11.0.3-notebook
+    labels:
+      opendatahub.io/build_type: "notebook_image"
+      opendatahub.io/notebook-name: "PyTorch"
+      rhods/buildchain: cuda
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'pytorch:py3.8-cuda-11.0.3-1'   <<<<<<<<< This must be changed to pytorch:py3.8-cuda-11.0.3-2 ..... (read on) ...
+    resources:
+      limits:
+        cpu: "4"
+        memory: 8Gi
+      requests:
+        cpu: "4"
+        memory: 8Gi
+    completionDeadlineSeconds: 1800
+    successfulBuildsHistoryLimit: 1
+    failedBuildsHistoryLimit: 1
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'minimal-gpu:py3.8-cuda-11.0.3'
+    postCommit: {}
+    source:
+      type: Git
+      git:
+        uri: 'https://github.com/red-hat-data-services/s2i-pytorch-notebook'
+        ref: nb-4                                                                <<<<<<<<<<< ... if this tag changes or the ultimate base image changes
+    triggers:
+      - type: ImageChange
+        imageChange: {}
+    runPolicy: SerialLatestOnly

--- a/jupyterhub/cuda-11.0.3/manifests.yaml
+++ b/jupyterhub/cuda-11.0.3/manifests.yaml
@@ -118,7 +118,7 @@ items:
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
-      name: "py3.8-cuda-11.0.3"
+      name: "py3.8-cuda-11.0.3-1"
       referencePolicy:
         type: Local
 - kind: ImageStream
@@ -142,7 +142,7 @@ items:
     - annotations:
         opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"1.15"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
-      name: "py3.8-cuda-11.0.3"
+      name: "py3.8-cuda-11.0.3-1"
       referencePolicy:
         type: Local
 
@@ -368,7 +368,7 @@ items:
     output:
       to:
         kind: ImageStreamTag
-        name: 'tensorflow:py3.8-cuda-11.0.3'
+        name: 'tensorflow:py3.8-cuda-11.0.3-1'
     resources:
       limits:
         cpu: "4"
@@ -408,7 +408,7 @@ items:
     output:
       to:
         kind: ImageStreamTag
-        name: 'pytorch:py3.8-cuda-11.0.3'
+        name: 'pytorch:py3.8-cuda-11.0.3-1'
     resources:
       limits:
         cpu: "4"


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2364
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Use the `quay.io/modh/rhods-operator-live-catalog:1.6.0-rhods-2364` version.

Install version `1.5.0-7`:

```
$ ./setup.sh quay.io/modh/qe-catalog-source:v150-7
```

Get image streams:

```
$ oc get is -n redhat-ods-applications
NAME                                IMAGE REPOSITORY                                                                                             TAGS 
pytorch                             image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/pytorch                             py3.8-cuda-11.0.3                                   
s2i-generic-data-science-notebook   image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook   py3.8
s2i-minimal-notebook                image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook                py3.8
tensorflow                          image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/tensorflow                          py3.8-cuda-11.0.3                      
```

Upgrade to `1.6.0-rhods-2364`:

``` 
$ oc patch catalogsource addon-managed-odh-catalog --type=merge \
    -p '{"spec":{"image":"quay.io/modh/rhods-operator-live-catalog:1.6.0-rhods-2364"}}' -n openshift-marketplace
```

Wait until the upgrade ends and get new image streams:

```
$ oc get is -n redhat-ods-applications
NAME                                IMAGE REPOSITORY                                                                                             TAGS 
pytorch                             image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/pytorch                             py3.8-cuda-11.0.3-1
s2i-generic-data-science-notebook   image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook   py3.8-1
s2i-minimal-notebook                image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-minimal-notebook                py3.8-1.6.0-rhods-2364
tensorflow                          image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/tensorflow                          py3.8-cuda-11.0.3-1
``` 

Spawn new notebooks using these images to verify they are using the new tag.