### PR TITLE
Update CRO version to 0.35.2

### DIFF
--- a/cloud-resource-operator/crds/integreatly.org_blobstorages.yaml
+++ b/cloud-resource-operator/crds/integreatly.org_blobstorages.yaml
@@ -14,69 +14,76 @@ spec:
     singular: blobstorage
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: BlobStorage is the Schema for the blobstorages API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              applyImmediately:
-                description: ApplyImmediately is only available to Postgres cr, for blobstorage and redis cr's currently does nothing
-                type: boolean
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                type: object
-              skipCreate:
-                type: boolean
-              tier:
-                type: string
-              type:
-                type: string
-            required:
-            - secretRef
-            - tier
-            - type
-            type: object
-          status:
-            properties:
-              message:
-                type: string
-              phase:
-                type: string
-              provider:
-                type: string
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                type: object
-              strategy:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: BlobStorage is the Schema for the blobstorages API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyImmediately:
+                  description: ApplyImmediately is only available to Postgres cr, for
+                    blobstorage and redis cr's currently does nothing
+                  type: boolean
+                secretRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                skipCreate:
+                  type: boolean
+                tier:
+                  type: string
+                type:
+                  type: string
+              required:
+                - secretRef
+                - tier
+                - type
+              type: object
+            status:
+              properties:
+                message:
+                  type: string
+                phase:
+                  type: string
+                provider:
+                  type: string
+                secretRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                strategy:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cloud-resource-operator/crds/integreatly.org_postgres.yaml
+++ b/cloud-resource-operator/crds/integreatly.org_postgres.yaml
@@ -14,69 +14,76 @@ spec:
     singular: postgres
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Postgres is the Schema for the postgres API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              applyImmediately:
-                description: ApplyImmediately is only available to Postgres cr, for blobstorage and redis cr's currently does nothing
-                type: boolean
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                type: object
-              skipCreate:
-                type: boolean
-              tier:
-                type: string
-              type:
-                type: string
-            required:
-            - secretRef
-            - tier
-            - type
-            type: object
-          status:
-            properties:
-              message:
-                type: string
-              phase:
-                type: string
-              provider:
-                type: string
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                type: object
-              strategy:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Postgres is the Schema for the postgres API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyImmediately:
+                  description: ApplyImmediately is only available to Postgres cr, for
+                    blobstorage and redis cr's currently does nothing
+                  type: boolean
+                secretRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                skipCreate:
+                  type: boolean
+                tier:
+                  type: string
+                type:
+                  type: string
+              required:
+                - secretRef
+                - tier
+                - type
+              type: object
+            status:
+              properties:
+                message:
+                  type: string
+                phase:
+                  type: string
+                provider:
+                  type: string
+                secretRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                strategy:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cloud-resource-operator/crds/integreatly.org_postgressnapshots.yaml
+++ b/cloud-resource-operator/crds/integreatly.org_postgressnapshots.yaml
@@ -14,42 +14,49 @@ spec:
     singular: postgressnapshot
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: PostgresSnapshot is the Schema for the postgressnapshots API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: PostgresSnapshotSpec defines the desired state of PostgresSnapshot
-            properties:
-              resourceName:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-                type: string
-            required:
-            - resourceName
-            type: object
-          status:
-            properties:
-              message:
-                type: string
-              phase:
-                type: string
-              snapshotID:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: PostgresSnapshot is the Schema for the postgressnapshots API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PostgresSnapshotSpec defines the desired state of PostgresSnapshot
+              properties:
+                resourceName:
+                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                  type: string
+              required:
+                - resourceName
+              type: object
+            status:
+              properties:
+                message:
+                  type: string
+                phase:
+                  type: string
+                snapshotID:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cloud-resource-operator/crds/integreatly.org_redis.yaml
+++ b/cloud-resource-operator/crds/integreatly.org_redis.yaml
@@ -14,69 +14,76 @@ spec:
     singular: redis
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Redis is the Schema for the redis API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              applyImmediately:
-                description: ApplyImmediately is only available to Postgres cr, for blobstorage and redis cr's currently does nothing
-                type: boolean
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                type: object
-              skipCreate:
-                type: boolean
-              tier:
-                type: string
-              type:
-                type: string
-            required:
-            - secretRef
-            - tier
-            - type
-            type: object
-          status:
-            properties:
-              message:
-                type: string
-              phase:
-                type: string
-              provider:
-                type: string
-              secretRef:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                type: object
-              strategy:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Redis is the Schema for the redis API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyImmediately:
+                  description: ApplyImmediately is only available to Postgres cr, for
+                    blobstorage and redis cr's currently does nothing
+                  type: boolean
+                secretRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                skipCreate:
+                  type: boolean
+                tier:
+                  type: string
+                type:
+                  type: string
+              required:
+                - secretRef
+                - tier
+                - type
+              type: object
+            status:
+              properties:
+                message:
+                  type: string
+                phase:
+                  type: string
+                provider:
+                  type: string
+                secretRef:
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                strategy:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cloud-resource-operator/crds/integreatly.org_redissnapshots.yaml
+++ b/cloud-resource-operator/crds/integreatly.org_redissnapshots.yaml
@@ -14,42 +14,47 @@ spec:
     singular: redissnapshot
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: RedisSnapshot is the Schema for the redissnapshots API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: RedisSnapshotSpec defines the desired state of RedisSnapshot
-            properties:
-              resourceName:
-                description: Foo is an example field of RedisSnapshot. Edit RedisSnapshot_types.go to remove/update
-                type: string
-            required:
-            - resourceName
-            type: object
-          status:
-            properties:
-              message:
-                type: string
-              phase:
-                type: string
-              snapshotID:
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: RedisSnapshot is the Schema for the redissnapshots API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RedisSnapshotSpec defines the desired state of RedisSnapshot
+              properties:
+                resourceName:
+                  description: Foo is an example field of RedisSnapshot. Edit RedisSnapshot_types.go
+                    to remove/update
+                  type: string
+              required:
+                - resourceName
+              type: object
+            status:
+              properties:
+                message:
+                  type: string
+                phase:
+                  type: string
+                snapshotID:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/cloud-resource-operator/deployment/cloud-resource-operator-deployment.yaml
+++ b/cloud-resource-operator/deployment/cloud-resource-operator-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloud-resource-operator
-          image: 'quay.io/modh/cloud-resource-operator-container:1.6.0-1'
+          image: 'quay.io/modh/cloud-resource-operator-container:v0.35.2'
           command:
             - cloud-resource-operator
           env:
@@ -30,7 +30,7 @@ spec:
             - name: TAG_KEY_PREFIX
               value: integreatly.org/
             - name: OPERATOR_CONDITION_NAME
-              value: cloud-resources.v0.30.0
+              value: cloud-resources.v0.35.2
           resources:
             limits:
               cpu: 50m

--- a/cloud-resource-operator/rbac/cloud-resource-operator-cluster-role.yaml
+++ b/cloud-resource-operator/rbac/cloud-resource-operator-cluster-role.yaml
@@ -25,3 +25,14 @@ rules:
       - monitoring.coreos.com
     resources:
       - prometheusrules
+  - verbs:
+      - list
+      - watch
+    apiGroups:
+      - integreatly.org
+    resources:
+      - postgres
+      - postgressnapshots
+      - redis
+      - redissnapshots
+


### PR DESCRIPTION
This commit updates the CRO version to include a fix that allows Postgres object
deletion with multiple addons.

Jira Issue: https://issues.redhat.com/browse/RHODS-2160

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s):
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
