### PR TITLE
Update to rhods applications networkpolicy for ocp 4.10

### DIFF
--- a/network/applications_network_policy.yaml
+++ b/network/applications_network_policy.yaml
@@ -17,18 +17,5 @@ spec:
         - namespaceSelector:
             matchLabels:
               opendatahub.io/generated-namespace: 'true'
-  egress:
-    - ports:
-        - protocol: TCP
-          port: 8443
-        - protocol: TCP
-          port: 8080
-        - protocol: TCP
-          port: 8081
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              opendatahub.io/generated-namespace: 'true'
   policyTypes:
     - Ingress
-    - Egress


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2743
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
