### PR TITLE
Update JH Build Failure Alert to Handle Running or Missing Previous Build

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -710,8 +710,21 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/spawner-greyed-images.md"
             build: "{{ $labels.buildconfig }}"
             summary: JupyterHub image builds are failing
-          expr: sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed", namespace="redhat-ods-applications"}) > sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed", namespace="redhat-ods-applications"} offset 10m)
-          for: 5m
+          expr: |
+            (
+              (1 - sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"running",namespace="redhat-ods-applications"}))  # Do not alert if there is a build actively running (this will make the left-hand side of the GT operator always 0 or negative and therefore false)
+              *
+              (sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"}))  # Get the current number of historical build failures at current time.  If its greater than the historical count from earlier, then a build failure has happened
+            )
+            >
+            (
+              sum by(buildconfig) (
+                (openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"} offset 30m)  # Compare this value (the number of historical build failures $offset time BEFORE current) against the current historical build failure count
+                or
+                (0 * openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"})  # This 'defaults' the historical build count above to 0, needed in case a the build label did not exist yet at that time.
+              )
+            )
+          for: 2m
           labels:
             severity: warning
 


### PR DESCRIPTION
- Add condition to not alert if a build is actively running for a particular label
- If no build exists in previous 30m, use 0 as a default value for historical build failure count to compare against
- RHODS-2051

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2051
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
