### PR TITLE
Add jupyterhub-cfg ConfigMap

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -99,6 +99,8 @@ export jupyterhub_prometheus_api_token=$(openssl rand -hex 32)
 sed -i "s/<jupyterhub_prometheus_api_token>/$jupyterhub_prometheus_api_token/g" monitoring/jupyterhub-prometheus-token-secrets.yaml
 oc create -n ${ODH_PROJECT} -f monitoring/jupyterhub-prometheus-token-secrets.yaml || echo "INFO: Jupyterhub scrape token already exist."
 
+sed -i "s/<notebook_destination>/$ODH_NOTEBOOK_PROJECT/g" jupyterhub/jupyterhub-configmap.yaml
+oc apply -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-configmap.yaml || echo "INFO: Jupyterhub ConfigMap already created "
 # Check if the installation target is OSD to determine the deployment manifest path
 deploy_on_osd=0
 oc get group dedicated-admins &> /dev/null || deploy_on_osd=1

--- a/jupyterhub/jupyterhub-configmap.yaml
+++ b/jupyterhub/jupyterhub-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyterhub
+  name: jupyterhub-cfg
+data:
+  jupyterhub_config.py: ""
+
+  jupyterhub_admins: "admin"
+  gpu_mode: ""
+  singleuser_pvc_size: 20Gi
+  notebook_destination: <notebook_destination>


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2638 
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)


**Testing Steps:**

- Install RHODS using catalogsource: quay.io/modh/rhods-operator-live-catalog:1.7.0-rhods-2638
-  Update PVC size in ConfigMap `jupyterhub-cfg`  under `redhat-ods-applications` namespace
-  Restart JupyterHub
- Spawn notebook server
- Verify PVC size in `rhods-notebooks` namespace. 

Related PR: https://github.com/red-hat-data-services/odh-manifests/pull/203

cc: @dlabaj