### PR TITLE
Changing default RHODS groups for RHODS 2442

### DIFF
--- a/groups/groups.configmap.yaml
+++ b/groups/groups.configmap.yaml
@@ -6,5 +6,5 @@ metadata:
     app: jupyterhub
   name: rhods-groups-config
 data:
-  admin_groups: "rhods-admins"
-  allowed_groups: "rhods-users"
+  admin_groups: "dedicated-admins"
+  allowed_groups: "system:authenticated"


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2442
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.
Live build:  quay.io/croberts/rhods-operator-live-catalog:1.8.0-0-jira-2442