### PR TITLE
Adding needed ports to ingress rule for non-OSD installs on OCP 4.10

### DIFF
--- a/network/applications_network_policy.yaml
+++ b/network/applications_network_policy.yaml
@@ -13,6 +13,14 @@ spec:
           port: 8080
         - protocol: TCP
           port: 8081
+        - protocol: TCP
+          port: 5432
+        - protocol: TCP
+          port: 8082
+        - protocol: TCP
+          port: 8099
+        - protocol: TCP
+          port: 8181  
     - from:
         - namespaceSelector:
             matchLabels:


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-3178
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.
