### PR TITLE
Update JH Build Failure Alert to Account for Successful Builds

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -712,14 +712,22 @@ data:
             summary: JupyterHub image builds are failing
           expr: |
             (
-              (1 - sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"running",namespace="redhat-ods-applications"}))  # Do not alert if there is a build actively running (this will make the left-hand side of the GT operator always 0 or negative and therefore false)
+              clamp( 1 - sum by (buildconfig) (openshift_build_status_phase_total{build_phase=~"running",namespace="redhat-ods-applications"}),0,1)  # Do not alert if is a build currently running(this will make the left-hand side of the GT operator 0 and therefore always false)
               *
-              (sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"}))  # Get the current number of historical build failures at current time.  If its greater than the historical count from earlier, then a build failure has happened
+              (
+                sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"})  # Get the current number of historical build failures at current time.  If its greater than the historical low water mark, then a build failure has happened
+                -
+                (
+                  sum by(buildconfig) (openshift_build_status_phase_total{build_phase=~"complete",namespace="redhat-ods-applications"})  # Subtract the value of the increase (over last 30m) in successful builds
+                  -
+                  sum by(buildconfig) (min_over_time(openshift_build_status_phase_total{build_phase=~"complete",namespace="redhat-ods-applications"}[30m]))
+                )
+              )
             )
             >
             (
               sum by(buildconfig) (
-                (openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"} offset 30m)  # Compare this value (the number of historical build failures $offset time BEFORE current) against the current historical build failure count
+                (min_over_time(openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"}[30m]))  # Compare this value (the lowest number of historical build failures $offset time BEFORE current) against the current historical build failure count
                 or
                 (0 * openshift_build_status_phase_total{build_phase=~"error|failed",namespace="redhat-ods-applications"})  # This 'defaults' the historical build count above to 0, needed in case a the build label did not exist yet at that time.
               )


### PR DESCRIPTION
- Update alert query to take successful builds into account
  to avoid false positives
- RHODS-2051

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2051
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.
