### PR TITLE
Fix for rhods groups on update

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -297,7 +297,7 @@ fi
 kind="configmap"
 resource="rhods-groups-config"
 object="rhods-groups-config"
-exists=$(oc get -n $ODH_PROJECT ${object} -o name | grep ${object} || echo "false")
+exists=$(oc get -n $ODH_PROJECT ${kind} ${object} -o name | grep ${object} || echo "false")
 # If this is a pre-existing cluster (ie: we are upgrading), then we will not touch the groups configmap
 # This is part of RHODS-2442 where we are changing the default groups.  The idea is for it to
 # not affect any pre-exisitng clusters that have already set up their access as they see fit.


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2442
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.
Live build image: quay.io/croberts/rhods-operator-live-catalog:1.8.0-9-jira-02442