### PR TITLE
Add culler timeout value and jh-idle-culler overlay

### DIFF
--- a/jupyterhub/jupyterhub-configmap.yaml
+++ b/jupyterhub/jupyterhub-configmap.yaml
@@ -11,3 +11,4 @@ data:
   gpu_mode: ""
   singleuser_pvc_size: 20Gi
   notebook_destination: <notebook_destination>
+  culler_timeout: "31536000" # 1 year in seconds

--- a/opendatahub-osd.yaml
+++ b/opendatahub-osd.yaml
@@ -23,6 +23,7 @@ spec:
       overlays:
         - jupyterhub-rds-db-patches
         - ui-config
+        - ../overlays/jupyterhub-idle-culler
       repoRef:
         name: manifests
         path: jupyterhub/jupyterhub/overrides

--- a/opendatahub.yaml
+++ b/opendatahub.yaml
@@ -25,6 +25,7 @@ spec:
         - jupyterhub-db-deployment-patch
         - jupyterhub-deployment-patch
         - ui-config
+        - ../overlays/jupyterhub-idle-culler
       repoRef:
         name: manifests
         path: jupyterhub/jupyterhub/overrides


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2324
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.

Testing instructions:
jupyterhub-cfg Configmap should be deploy with the culler_timeout value in data
jupyterhub-idle-culler deployment config should be present and deployed.

Replaces #216 