### PR TITLE
Update SLO in Prometheus

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -222,9 +222,9 @@ data:
             triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate5m{route=~"rhods-dashboard"}) by (route) > (14.40 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate5m{route=~"rhods-dashboard"}) by (route) > (14.40 * (1-0.99950))
             and
-            sum(haproxy_backend_http_responses_total:burnrate1h{route=~"rhods-dashboard"}) by (route) > (14.40 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate1h{route=~"rhods-dashboard"}) by (route) > (14.40 * (1-0.99950))
           for: 2m
           labels:
             severity: critical
@@ -234,9 +234,9 @@ data:
             triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate30m{route=~"rhods-dashboard"}) by (route) > (6.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate30m{route=~"rhods-dashboard"}) by (route) > (6.00 * (1-0.99950))
             and
-            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"rhods-dashboard"}) by (route) > (6.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"rhods-dashboard"}) by (route) > (6.00 * (1-0.99950))
           for: 15m
           labels:
             severity: critical
@@ -246,9 +246,9 @@ data:
             triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate2h{route=~"rhods-dashboard"}) by (route) > (3.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate2h{route=~"rhods-dashboard"}) by (route) > (3.00 * (1-0.99950))
             and
-            sum(haproxy_backend_http_responses_total:burnrate1d{route=~"rhods-dashboard"}) by (route) > (3.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate1d{route=~"rhods-dashboard"}) by (route) > (3.00 * (1-0.99950))
           for: 1h
           labels:
             severity: warning
@@ -258,9 +258,9 @@ data:
             triage: '{{if eq $labels.route "jupyterhub"}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-error-burn-rate.md{{else}}https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md{{end}}'
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"rhods-dashboard"}) by (route) > (1.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"rhods-dashboard"}) by (route) > (1.00 * (1-0.99950))
             and
-            sum(haproxy_backend_http_responses_total:burnrate3d{route=~"rhods-dashboard"}) by (route) > (1.00 * (1-0.98000))
+            sum(haproxy_backend_http_responses_total:burnrate3d{route=~"rhods-dashboard"}) by (route) > (1.00 * (1-0.99950))
           for: 3h
           labels:
             severity: warning
@@ -296,9 +296,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate5m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate5m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.99950))
             and
-            sum(probe_success:burnrate1h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate1h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (14.40 * (1-0.99950))
           for: 2m
           labels:
             severity: critical
@@ -308,9 +308,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate30m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate30m{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.99950))
             and
-            sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (6.00 * (1-0.99950))
           for: 15m
           labels:
             severity: critical
@@ -320,9 +320,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate2h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate2h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.99950))
             and
-            sum(probe_success:burnrate1d{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate1d{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (3.00 * (1-0.99950))
           for: 1h
           labels:
             severity: warning
@@ -332,9 +332,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
             summary: RHODS Route Error Burn Rate
           expr: |
-            sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.99950))
             and
-            sum(probe_success:burnrate3d{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate3d{instance=~"jupyterhub|rhods-dashboard|jupyterhub-db|traefik"}) by (instance) > (1.00 * (1-0.99950))
           for: 3h
           labels:
             severity: warning


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-3947
- [x] The Jira story is acked
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [X] The developer has manually tested the changes and verified that the changes work.

## Live Build
quay.io/lferrnan/rhods-operator-live-catalog:1.11.1-prometheus-slo

## Testing instructions

1. Install the live build in a cluster
2. Login to RHODS Prometheus
3. Go to Status > Rules
4. Verify the expression for SLOs-haproxy_backend_http_responses_total and SLOs-probe_success
