### PR TITLE
Update prometheus rhods_aggregate_availability metric 

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -197,7 +197,7 @@ data:
 
       - name: Availability Metrics
         rules:
-        - expr: min(probe_success)
+        - expr: (min(min_over_time(probe_success[10s])) by (instance) or label_replace(min(min_over_time(probe_success[10s])), "instance", "combined", "instance", ".*"))
           record: rhods_aggregate_availability
 
   alerting.rules: |


### PR DESCRIPTION
Updated the rhods_aggregate_availability metric to include a label indicating the availability of each component over time. 

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4229
- [x] The Jira story is acked
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [x] The developer has manually tested the changes and verified that the changes work.

### Live Build

quay.io/repository/modh/rhods-operator-live-catalog:1.13.0-rhods-4229

### Testing Instructions

1. Deploy the live build
2. Kill all the jupyterhub pods
3. Enter prometheus, check that in rhods_aggregate_availability both "combined" and "jupyterhub" vectors are down
4. Kill all dashboard pods
5. Enter prometheus, check that in rhods_aggregate_availability both "combined" and "dashboard" vectors are down
