### PR TITLE
Change apply to create command to prevent overwriting of jh-cfg

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -100,7 +100,8 @@ sed -i "s/<jupyterhub_prometheus_api_token>/$jupyterhub_prometheus_api_token/g" 
 oc create -n ${ODH_PROJECT} -f monitoring/jupyterhub-prometheus-token-secrets.yaml || echo "INFO: Jupyterhub scrape token already exist."
 
 sed -i "s/<notebook_destination>/$ODH_NOTEBOOK_PROJECT/g" jupyterhub/jupyterhub-configmap.yaml
-oc apply -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-configmap.yaml || echo "INFO: Jupyterhub ConfigMap already created "
+# Requires oc create instead of apply to prevent overwriting.
+oc create -n ${ODH_PROJECT} -f jupyterhub/jupyterhub-configmap.yaml || echo "INFO: Jupyterhub ConfigMap already created "
 
 infrastructure=$(oc get infrastructure cluster -o jsonpath='{.spec.platformSpec.type}')
 # Check if the installation target is AWS to determine the deployment manifest path


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4366
- [ ] The Jira story is acked
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
- [ ] The developer has manually tested the changes and verified that the changes work.

Testing: 
1. Add custom values to the `jupyterhub-cfg` configmap
2. Update or redeploy RHODS
3. Verify that custom values are not overwritten
