### PR TITLE
KFNBC alert rules have been defined in prometheus server configuration

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -421,6 +421,26 @@ data:
           labels:
             severity: warning
 
+      - name: RHODS Notebook controllers
+        rules:
+        - alert: Kubeflow notebook controller pod is not running
+          annotations:
+            message: 'Kubeflow Notebook controller is down!'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"
+            summary: Kubeflow notebook controller pod is not running
+          expr: sum(up{job=~'Kubeflow Notebook Controller Service Metrics'})
+          for: 5m
+          labels:
+            severity: warning
+        - alert: ODH notebook controller pod is not running
+          annotations:
+            message: 'ODH notebook controller is down!'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
+            summary: ODH notebook controller pod is not running
+          expr: sum(up{job=~'ODH Notebook Controller Service Metrics'})
+          for: 5m
+          labels:
+            severity: warning
 
   prometheus.yml: |
     rule_files:
@@ -517,6 +537,44 @@ data:
         target_label: instance
       - target_label: __address__
         replacement: blackbox-exporter.redhat-ods-monitoring.svc.cluster.local:9114
+
+    - job_name: 'Kubeflow Notebook Controller Service Metrics'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(notebook-controller-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'ODH Notebook Controller Service Metrics'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(odh-notebook-controller-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
 
     - job_name: 'RHODS Metrics'
       honor_labels: true


### PR DESCRIPTION
The new alert rules for the KFNBC have been defined in Prometheus server configuration.

## Description
These two new additions are implementing the monitoring of kubeflow notebook controller and odh notebook controller according to the new architecture of Jupyter notebook.  
Have been added two alerts:

- alert_rule:  Kubeflow notebook controller
- alert_rule: ODH notebook controller

and the according scrape jobs:

- job_name: 'Kubeflow Notebook Controller Service Metrics'
- job_name: 'ODH Notebook Controller Service Metrics'


## How Has This Been Tested?
Access to the Prometheus Dashboard -> Targets and Alerts tabs and see the status

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4228
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
