### PR TITLE
Update contributing guide using OWNER_ALIASES

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,12 @@ When contributing to this repository, please first discuss the change you wish t
 - Sign off your commit using the -s, --signoff option. Write a good commit message (see [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/))
 - Push your changes
 - Send a PR to odh-deployer using GitHub's web interface
+- We are using OpenShift CI to control merges to the deployer repository. PRs will automatically be merged when the following conditions are met:
+  - A `lgtm` label has been added by a reviewer
+  - An `approved` label has been added by an approver
+  - A `qe-approved` label has been added by a QE member
+  - The [OWNERS_ALIASES](https://github.com/red-hat-data-services/odh-deployer/blob/main/OWNERS_ALIASES) file of the repository has a list of the people who can review, approve, and qe-approve PRs.
+
 
 ### Testing the PR
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,5 @@
 approvers:
-  - crobby
-  - anishasthana
-  - LaVLaS
-  - VaishnaviHire
-  - lucferbux
+  - dev-approvers
 reviewers:
-  - crobby
-  - anishasthana
-  - LaVLaS
-  - VaishnaviHire
-  - lucferbux
+  - dev-reviewers
+  - qe-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,19 @@
+aliases:
+  # folks who can approve and APPROVED any PRs in the repo
+  dev-approvers:
+    - anishasthana
+    - crobby
+    - LaVLaS
+    - lucferbux
+    - VaishnaviHire
+  # folks who can review and LGTM any PRs in the repo
+  dev-reviewers:
+    - anishasthana
+    - crobby
+    - LaVLaS
+    - lucferbux
+    - VaishnaviHire
+  # folks who can review/test and QE-APPROVED any PRs in the repo
+  qe-approvers:
+    - pablofelix
+    - tarukumar


### PR DESCRIPTION
Added instructions about how to use tide plugin of openshift ci into contribution.md file.
Updated the OWNERS file to use OWNERS_ALIASES 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2769, https://issues.redhat.com/browse/RHODS-3396
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
