### PR TITLE
Corrected kfnbc alert rule expressions to firing when the pods are unreachable

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -436,7 +436,7 @@ data:
             message: 'Kubeflow Notebook controller is down!'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"
             summary: Kubeflow notebook controller pod is not running
-          expr: sum(up{job=~'Kubeflow Notebook Controller Service Metrics'})
+          expr: absent(up{job=~'Kubeflow Notebook Controller Service Metrics'})
           for: 5m
           labels:
             severity: warning
@@ -445,7 +445,7 @@ data:
             message: 'ODH notebook controller is down!'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
             summary: ODH notebook controller pod is not running
-          expr: sum(up{job=~'ODH Notebook Controller Service Metrics'})
+          expr: absent(up{job=~'ODH Notebook Controller Service Metrics'})
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
Corrected kfnbc alert rule expressions to firing when the pods are unreachable

## Description
While I was working on Prometheus alerts, I observed that the `RHODS Notebook controllers` alerts presented a false firing. 
The pods of the kfnbc and odh controllers on the other hand was working properly. 
The reason that the Firing alarm was triggered was because of missing in the end of the expression `== 0`

[Reference about how to alert for any instance that is unreachable](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/#templating)

## How Has This Been Tested?
Ensure that the `notebook-controller-deployment-xxxxx-xxx` is down for more than 5 mins
Ensure that the `odh-notebook-controller-manager-xxxxx-xxx` is down for more than 5 mins

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
