### PR TITLE
Update rhods prometheus stack according the kfnbc migration

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -217,11 +217,13 @@ pagerduty_service_token=$(echo -ne "$pagerduty_service_token" | tr -d "'" | base
 oc apply -f monitoring/jupyterhub-route.yaml -n $ODH_PROJECT
 oc apply -f monitoring/rhods-dashboard-route.yaml -n $ODH_PROJECT
 
-jupyterhub_host=$(oc::wait::object::availability "oc get route jupyterhub -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
 rhods_dashboard_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
 
-sed -i "s/<jupyterhub_host>/$jupyterhub_host/g" monitoring/prometheus/prometheus-configs.yaml
+NOTEBOOK_SUFFIX="\/notebookController\/spawner"
+notebook_spawner_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'$NOTEBOOK_SUFFIX'" 2 30 | tr -d "'")
+
 sed -i "s/<rhods_dashboard_host>/$rhods_dashboard_host/g" monitoring/prometheus/prometheus-configs.yaml
+sed -i "s/<notebook_spawner_host>/$notebook_spawner_host/g" monitoring/prometheus/prometheus-configs.yaml
 sed -i "s/<pagerduty_token>/$pagerduty_service_token/g" monitoring/prometheus/prometheus-configs.yaml
 sed -i "s/<set_alertmanager_host>/$alertmanager_host/g" monitoring/prometheus/prometheus.yaml
 
@@ -278,9 +280,11 @@ alertmanager_config=$(oc get cm alertmanager -n $ODH_MONITORING_PROJECT -o jsonp
 
 sed -i "s#<prometheus_config_hash>#$prometheus_config#g" monitoring/prometheus/prometheus.yaml
 sed -i "s#<alertmanager_config_hash>#$alertmanager_config#g" monitoring/prometheus/prometheus.yaml
+sed -i "s#<odh_monitoring_project>#$ODH_MONITORING_PROJECT#g" monitoring/prometheus/prometheus-viewer-rolebinding.yaml
 
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus.yaml
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/grafana/grafana-sa.yaml
+oc apply -n $ODH_PROJECT -f monitoring/prometheus/prometheus-viewer-rolebinding.yaml
 
 
 prometheus_route=$(oc::wait::object::availability "oc get route prometheus -n $ODH_MONITORING_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")

--- a/monitoring/prometheus/blackbox-exporter-external.yaml
+++ b/monitoring/prometheus/blackbox-exporter-external.yaml
@@ -11,7 +11,8 @@ data:
         timeout: 10s
         http:
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208]
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           method: GET
           no_follow_redirects: false
           fail_if_ssl: false

--- a/monitoring/prometheus/blackbox-exporter-internal.yaml
+++ b/monitoring/prometheus/blackbox-exporter-internal.yaml
@@ -12,7 +12,8 @@ data:
         http:
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
           method: GET
-          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208]
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           tls_config:
             insecure_skip_verify: true
           preferred_ip_protocol: "ip4"

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -15,90 +15,6 @@ metadata:
 data:
   recording.rules: |
     groups:
-      - name: SLOs - JupyterHub
-        rules:
-        # The haproxy errors SLO for JupyterHub is disabled. Context at https://issues.redhat.com/browse/RHODS-2101
-
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[1d])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate1d
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[1h])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate1h
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[2h])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate2h
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[30m])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate30m
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[3d])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate3d
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[5m])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate5m
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"jupyterhub-.*", job="user_facing_endpoints_status"}[6h])
-          labels:
-            instance: jupyterhub
-          record: probe_success:burnrate6h
-
-      - name: SLOs - Traefik Proxy
-        rules:
-        - expr: min(up{job="Traefik Proxy Metrics"})
-          labels:
-            instance: traefik
-            job: user_facing_endpoints_status
-          record:
-            probe_success
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[1d])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate1d
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[1h])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate1h
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[2h])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate2h
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[30m])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate30m
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[3d])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate3d
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[5m])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate5m
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"traefik", job="user_facing_endpoints_status"}[6h])
-          labels:
-            instance: traefik
-          record: probe_success:burnrate6h
-
       - name: SLOs - ODH Dashboard
         rules:
         - expr: |
@@ -198,14 +114,18 @@ data:
 
       - name: Usage Metrics
         rules:
-        - expr: max(jupyterhub_total_users)
-          labels:
-            instance: jupyterhub
+        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
           record: rhods_total_users
+          labels:
+            instance: jupyter-notebooks
+        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+          record: rhods_active_users
+          labels:
+            instance: jupyter-notebooks
 
       - name: Availability Metrics
         rules:
-        - expr: ((min(probe_success{instance=~"jupyterhub-redhat-ods-applications.*|rhods-dashboard-redhat-ods-applications.*"}) by (instance) or on() vector(0)) or label_replace(min(probe_success{instance=~"jupyterhub-redhat-ods-applications.*|rhods-dashboard-redhat-ods-applications.*"}), "instance", "combined", "instance", ".*"))
+        - expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
           record: rhods_aggregate_availability
 
   alerting.rules: |
@@ -298,111 +218,111 @@ data:
 
       - name: SLOs-probe_success
         rules:
-        - alert: RHODS JupyterHub Probe Success Burn Rate
+        - alert: RHODS Jupyter Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS JupyterHub Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate5m{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate5m{name=~"notebook-spawner"}) by (name) > (14.40 * (1-0.98000))
             and
-            sum(probe_success:burnrate1h{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate1h{name=~"notebook-spawner"}) by (name) > (14.40 * (1-0.98000))
           for: 2m
           labels:
             severity: critical
-        - alert: RHODS JupyterHub Probe Success Burn Rate
+        - alert: RHODS Jupyter Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS JupyterHub Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate30m{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate30m{name=~"notebook-spawner"}) by (name) > (6.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate6h{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{name=~"notebook-spawner"}) by (name) > (6.00 * (1-0.98000))
           for: 15m
           labels:
             severity: critical
-        - alert: RHODS JupyterHub Probe Success Burn Rate
+        - alert: RHODS Jupyter Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS JupyterHub Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate2h{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate2h{name=~"notebook-spawner"}) by (name) > (3.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate1d{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate1d{name=~"notebook-spawner"}) by (name) > (3.00 * (1-0.98000))
           for: 1h
           labels:
             severity: warning
-        - alert: RHODS JupyterHub Probe Success Burn Rate
+        - alert: RHODS Jupyter Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS JupyterHub Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate6h{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{name=~"notebook-spawner"}) by (name) > (1.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate3d{instance=~"jupyterhub|jupyterhub-db"}) by (instance) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate3d{name=~"notebook-spawner"}) by (name) > (1.00 * (1-0.98000))
           for: 3h
           labels:
             severity: warning
-        - alert: RHODS Probe Success Burn Rate
+        - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate5m{instance=~"rhods-dashboard|traefik"}) by (instance) > (14.40 * (1-0.99950))
+            sum(probe_success:burnrate5m{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
             and
-            sum(probe_success:burnrate1h{instance=~"rhods-dashboard|traefik"}) by (instance) > (14.40 * (1-0.99950))
+            sum(probe_success:burnrate1h{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
           for: 2m
           labels:
             severity: warning
-        - alert: RHODS Probe Success Burn Rate
+        - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate30m{instance=~"rhods-dashboard|traefik"}) by (instance) > (6.00 * (1-0.99950))
+            sum(probe_success:burnrate30m{name=~"rhods-dashboard"}) by (name) > (6.00 * (1-0.99950))
             and
-            sum(probe_success:burnrate6h{instance=~"rhods-dashboard|traefik"}) by (instance) > (6.00 * (1-0.99950))
+            sum(probe_success:burnrate6h{name=~"rhods-dashboard"}) by (name) > (6.00 * (1-0.99950))
           for: 15m
           labels:
             severity: warning
-        - alert: RHODS Probe Success Burn Rate
+        - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate2h{instance=~"rhods-dashboard|traefik"}) by (instance) > (3.00 * (1-0.99950))
+            sum(probe_success:burnrate2h{name=~"rhods-dashboard"}) by (name) > (3.00 * (1-0.99950))
             and
-            sum(probe_success:burnrate1d{instance=~"rhods-dashboard|traefik"}) by (instance) > (3.00 * (1-0.99950))
+            sum(probe_success:burnrate1d{name=~"rhods-dashboard"}) by (name) > (3.00 * (1-0.99950))
           for: 1h
           labels:
             severity: warning
-        - alert: RHODS Probe Success Burn Rate
+        - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/rhods-probe-success-burn-rate.md"
-            summary: RHODS Probe Success Burn Rate
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate6h{instance=~"rhods-dashboard|traefik"}) by (instance) > (1.00 * (1-0.99950))
+            sum(probe_success:burnrate6h{name=~"rhods-dashboard"}) by (name) > (1.00 * (1-0.99950))
             and
-            sum(probe_success:burnrate3d{instance=~"rhods-dashboard|traefik"}) by (instance) > (1.00 * (1-0.99950))
+            sum(probe_success:burnrate3d{name=~"rhods-dashboard"}) by (name) > (1.00 * (1-0.99950))
           for: 3h
           labels:
             severity: warning
 
       - name: Builds
         rules:
-        - alert: JupyterHub image builds are failing
+        - alert: Jupyter image builds are failing
           annotations:
-            message: 'A JupyterHub image build is in a failed state.'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/JupyterHub/spawner-greyed-images.md"
+            message: 'A Jupyter image build is in a failed state.'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/spawner-greyed-images.md"
             build: "{{ $labels.buildconfig }}"
-            summary: JupyterHub image builds are failing
+            summary: Jupyter image builds are failing
           expr: |
             (
               clamp( 1 - sum by (buildconfig) (openshift_build_status_phase_total{build_phase=~"running",namespace="redhat-ods-applications"}),0,1)  # Do not alert if is a build currently running(this will make the left-hand side of the GT operator 0 and therefore always false)
@@ -436,7 +356,7 @@ data:
             message: 'Kubeflow Notebook controller is down!'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"
             summary: Kubeflow notebook controller pod is not running
-          expr: sum(up{job=~'Kubeflow Notebook Controller Service Metrics'})
+          expr: absent(up{job=~'Kubeflow Notebook Controller Service Metrics'})
           for: 5m
           labels:
             severity: warning
@@ -445,7 +365,7 @@ data:
             message: 'ODH notebook controller is down!'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
             summary: ODH notebook controller pod is not running
-          expr: sum(up{job=~'ODH Notebook Controller Service Metrics'})
+          expr: absent(up{job=~'ODH Notebook Controller Service Metrics'})
           for: 5m
           labels:
             severity: warning
@@ -480,49 +400,12 @@ data:
           - '{__name__= "kube_pod_container_status_restarts_total"}'
           - '{__name__= "kube_pod_container_status_terminated_reason"}'
           - '{__name__= "openshift_build_status_phase_total"}'
+          - '{__name__= "kube_statefulset_replicas"}'
+
 
       static_configs:
         - targets:
           - "prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
-
-    - job_name: 'JupyterHub Metrics'
-      honor_labels: true
-      metrics_path: /hub/metrics
-      scheme: http
-      bearer_token: <jupyterhub_prometheus_api_token>
-      kubernetes_sd_configs:
-        - role: endpoints
-          namespaces:
-            names:
-              - redhat-ods-applications
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(jupyterhub)$
-          target_label: kubernetes_name
-          action: keep
-        - source_labels: [__address__]
-          regex: (.+):(\d+)
-          target_label: __address__
-          replacement: ${1}:8081
-
-    - job_name: 'Traefik Proxy Metrics'
-      honor_labels: true
-      metrics_path: /metrics
-      scheme: http
-      kubernetes_sd_configs:
-        - role: endpoints
-          namespaces:
-            names:
-              - redhat-ods-applications
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(traefik-proxy)$
-          target_label: kubernetes_name
-          action: keep
-        - source_labels: [__address__]
-          regex: (.+):(\d+)
-          target_label: __address__
-          replacement: ${1}:8082
 
     - job_name: 'user_facing_endpoints_status'
       scrape_interval: 10s
@@ -535,9 +418,12 @@ data:
       authorization:
         credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
       static_configs:
-      - targets:
-        - <jupyterhub_host>
-        - <rhods_dashboard_host>
+      - targets: [<rhods_dashboard_host>]
+        labels:
+          name: rhods-dashboard
+      - targets: [<notebook_spawner_host>]
+        labels:
+          name: notebook-spawner
       relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/monitoring/prometheus/prometheus-viewer-rolebinding.yaml
+++ b/monitoring/prometheus/prometheus-viewer-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhods-prometheus-viewer
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: <odh_monitoring_project>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -32,7 +32,7 @@ spec:
           command:
             - /bin/sh
             - '-c'
-            - for i in `seq 1 230`; do sleep 10; echo "Waiting for traefik-proxy service to become available..."; if curl -s http://traefik-proxy.redhat-ods-applications.svc:8080; then exit 0; fi; done; exit 1
+            - for i in `seq 1 230`; do sleep 10; echo "Waiting for odh-notebook-controller-service to become available..."; if curl -I http://odh-notebook-controller-service.redhat-ods-applications.svc:8080/metrics; then exit 0; fi; done; exit 1
       containers:
       - name: oauth-proxy
         args:


### PR DESCRIPTION
This PR cleans up the obsolete monitoring targets, alerts, and recording rules from the Prometheus configuration

## Description
Applied the following changes:

- Removed Traefik
- Removed Jupyterhub and JupyterhubDB
- Added monitoring target for Jupyter notebook spawner page (Dependent by this PR https://github.com/red-hat-data-services/odh-deployer/pull/258)
- Updated the rhods_aggregate_availability metric to check also the spawner
- Corrected kfnbc alert rule expressions to firing when the pods are unreachable 

## How Has This Been Tested?

- Ensure that Traefik proxy doesn't exist on **recording rules** and on RHODS Probe Success Burn Rate **alert rules**
- Ensure that Jupyterhub doesn't exist on **recording rules** 
- To ensure that Usage Metrics work 
  - for **rhods_total_users** try to create and delete multiple notebooks with different users
  - for **rhods_active_users** try to create multiple notebooks with different users 
- Ensure that alerts for Jupyter notebook spawner are working
  - to check if the spawner reacts as expected delete the ServiceAccounts notebook-controller-service-account, odh-notebook-controller-manager, and rhods-dashboard and monitor the downtime via rhods_aggregate_availability (That is going to disturb the communication)
- Ensure that the rhods_aggregate_availability metric displays correctly the downtime of rhods-dashboard, notebook-spawner and combined
- To test the KFNBC alerts:
  - Ensure that the notebook-controller-deployment-xxxxx-xxx is down for more than 5 mins
  - Ensure that the odh-notebook-controller-manager-xxxxx-xxx is down for more than 5 mins

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4765
- [ ] The Jira story is acked.
- [x] Live build image: quay.io/accorvin/rhods-operator-live-catalog:1.0.0-[rhods-4765](https://issues.redhat.com//browse/rhods-4765)
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
