### PR TITLE
WIP: configure the blackbox exporter to authenticate to probed services

### DIFF
--- a/monitoring/prometheus/blackbox-exporter-external.yaml
+++ b/monitoring/prometheus/blackbox-exporter-external.yaml
@@ -11,7 +11,7 @@ data:
         timeout: 10s
         http:
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
-          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208]
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           method: GET
           no_follow_redirects: false

--- a/monitoring/prometheus/blackbox-exporter-external.yaml
+++ b/monitoring/prometheus/blackbox-exporter-external.yaml
@@ -12,6 +12,7 @@ data:
         http:
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
           valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           method: GET
           no_follow_redirects: false
           fail_if_ssl: false

--- a/monitoring/prometheus/blackbox-exporter-internal.yaml
+++ b/monitoring/prometheus/blackbox-exporter-internal.yaml
@@ -12,7 +12,7 @@ data:
         http:
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
           method: GET
-          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208]
           bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           tls_config:
             insecure_skip_verify: true

--- a/monitoring/prometheus/blackbox-exporter-internal.yaml
+++ b/monitoring/prometheus/blackbox-exporter-internal.yaml
@@ -13,6 +13,7 @@ data:
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
           method: GET
           valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208, 403]
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
           tls_config:
             insecure_skip_verify: true
           preferred_ip_protocol: "ip4"


### PR DESCRIPTION
## Description
The blackbox exporter was never configured to authenticate to our services when it runs a probe. All along, our probes have just been hitting the oauth proxy container and not actually exercising our application code. This change addresses this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
