### PR TITLE
Remove explicit CUDA version from imagestreamtag

### DIFF
--- a/nbc/cuda-11.4.2/manifests.yaml
+++ b/nbc/cuda-11.4.2/manifests.yaml
@@ -94,7 +94,7 @@ items:
       local: true
     tags:
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"CUDA","version":"11.4"}]'
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2.4"},{"name":"Notebook","version":"6.4"}]'
       name: "py3.8-cuda-11.4.2"
       referencePolicy:
@@ -118,7 +118,7 @@ items:
       local: true
     tags:
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"},{"name":"CUDA","version":"11.4"}]'
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
       name: "py3.8-cuda-11.4.2-2"
       referencePolicy:
@@ -142,7 +142,7 @@ items:
       local: true
     tags:
     - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"},{"name":"CUDA","version":"11.4"}]'
+        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
       name: "py3.8-cuda-11.4.2-2"
       referencePolicy:


### PR DESCRIPTION
This is due to [RHODS-4312](https://issues.redhat.com//browse/RHODS-4312) which notes that in some cases a driver update can occur without a corresponding update to RHODS, leaving the spawner showing a CUDA version that is inconsistent with the version displayed in the notebook at runtime. It might be a good idea to get this from the driver somehow, but since that requires a lot of rearchitecting, this just removes the explicit version from the mouseover text

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-4312
- [X] The Jira story is acked.
- [x] Live build image: 
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
