### PR TITLE
Fix RHODS Jupyter Probe Success Burn Rate

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -191,10 +191,9 @@ pagerduty_service_token=$(echo -ne "$pagerduty_service_token" | tr -d "'" | base
 
 oc apply -f monitoring/rhods-dashboard-route.yaml -n $ODH_PROJECT
 
-rhods_dashboard_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
 
-NOTEBOOK_SUFFIX="\/notebookController\/spawner"
-notebook_spawner_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'$NOTEBOOK_SUFFIX'" 2 30 | tr -d "'")
+rhods_dashboard_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
+notebook_spawner_host="notebook-controller-service.$ODH_PROJECT.svc:8080\/metrics,odh-notebook-controller-service.$ODH_PROJECT.svc:8080\/metrics"
 
 sed -i "s/<rhods_dashboard_host>/$rhods_dashboard_host/g" monitoring/prometheus/prometheus-configs.yaml
 sed -i "s/<notebook_spawner_host>/$notebook_spawner_host/g" monitoring/prometheus/prometheus-configs.yaml

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -103,6 +103,44 @@ data:
             instance: rhods-dashboard
           record: probe_success:burnrate6h
 
+      - name: SLOs - Notebook Controller
+        rules:
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[1d]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner",job="user_facing_endpoints_status"}[1h]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[2h]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner",job="user_facing_endpoints_status"}[30m]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[3d]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[5m]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner",job="user_facing_endpoints_status"}[6h]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate6h
+
       - name: SLOs - RHODS Operator
         interval: 15m
         rules:
@@ -224,9 +262,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
             summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate5m{name=~"notebook-spawner"}) by (name) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate5m{instance=~"notebook-spawner"}) by (instance) > (14.40 * (1-0.98000))
             and
-            sum(probe_success:burnrate1h{name=~"notebook-spawner"}) by (name) > (14.40 * (1-0.98000))
+            sum(probe_success:burnrate1h{instance=~"notebook-spawner"}) by (instance) > (14.40 * (1-0.98000))
           for: 2m
           labels:
             severity: critical
@@ -236,9 +274,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
             summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate30m{name=~"notebook-spawner"}) by (name) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate30m{instance=~"notebook-spawner"}) by (instance) > (6.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate6h{name=~"notebook-spawner"}) by (name) > (6.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{instance=~"notebook-spawner"}) by (instance) > (6.00 * (1-0.98000))
           for: 15m
           labels:
             severity: critical
@@ -248,9 +286,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
             summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate2h{name=~"notebook-spawner"}) by (name) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate2h{instance=~"notebook-spawner"}) by (instance) > (3.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate1d{name=~"notebook-spawner"}) by (name) > (3.00 * (1-0.98000))
+            sum(probe_success:burnrate1d{instance=~"notebook-spawner"}) by (instance) > (3.00 * (1-0.98000))
           for: 1h
           labels:
             severity: warning
@@ -260,9 +298,9 @@ data:
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
             summary: RHODS Jupyter Probe Success Burn Rate
           expr: |
-            sum(probe_success:burnrate6h{name=~"notebook-spawner"}) by (name) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate6h{instance=~"notebook-spawner"}) by (instance) > (1.00 * (1-0.98000))
             and
-            sum(probe_success:burnrate3d{name=~"notebook-spawner"}) by (name) > (1.00 * (1-0.98000))
+            sum(probe_success:burnrate3d{instance=~"notebook-spawner"}) by (instance) > (1.00 * (1-0.98000))
           for: 3h
           labels:
             severity: warning
@@ -506,7 +544,7 @@ data:
         {{ if gt (len .Alerts.Firing) 1 }}
             Red Hat OpenShift Data Science Notifications
         {{ else }}
-            {{ (index .Alerts.Firing 0).Annotations.summary }} 
+            {{ (index .Alerts.Firing 0).Annotations.summary }}
         {{ end }}
     {{ end }}
     {{ define "email.rhods.html" }}


### PR DESCRIPTION
This PR fixes the RHODS Jupyter Probe Success Burn Rate alarm fault. 

## Description
After investigation with @lucferbux, we observed that during the kfnbc migration, we deleted the SLOs - JupterHub recording rules without updating them for the notebook controller. 
Furthermore, we updated the notebook-spawner target to the blackbox exporter to watch the `notebook-controller-service`

## How Has This Been Tested?

- Scale down to 0 rhods-operator
- Scale down to 0 notebook-controller-deployment
- Scale down to 0 odh-notebook-controller-manager
- Wait 5 mins until alerts "Kubeflow notebook controller pod is not running" and "ODH notebook controller pod is not running" are firing
- Try to spawn a notebook. You'll see the error "Failed to create a notebook, please try again later"
- Verify that the alert "RHODS Jupyter Probe Success Burn Rate" is firing after 10++ mins

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5205
- [x] The Jira story is acked.
- [x] Live build image:  quay.io/modh/rhods-operator-live-catalog:1.18.0-[rhods-5205](https://issues.redhat.com//browse/rhods-5205)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
