### PR TITLE
Deploy modelmesh and modelmesh monitoring stack

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -149,6 +149,12 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+oc apply -n ${ODH_PROJECT} -f rhods-model-mesh.yaml
+if [ $? -ne 0 ]; then
+  echo "ERROR: Attempt to create the Model Mesh CR failed."
+  exit 1
+fi
+
 # Create KfDef for RHODS Notebooks ImageStreams
 oc apply -n ${ODH_NOTEBOOK_PROJECT} -f rhods-notebooks.yaml
 if [ $? -ne 0 ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -163,6 +163,13 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Create KfDef for RHODS Model Mesh monitoring stack
+oc apply -n ${ODH_MONITORING_PROJECT} -f rhods-modelmesh-monitoring.yaml
+if [ $? -ne 0 ]; then
+  echo "ERROR: Attempt to create the RHODS monitoring stack failed."
+  exit 1
+fi
+
 # Create KfDef for Anaconda
 oc apply -n ${ODH_PROJECT} -f rhods-anaconda.yaml
 if [ $? -ne 0 ]; then

--- a/kfdefs/rhods-model-mesh.yaml
+++ b/kfdefs/rhods-model-mesh.yaml
@@ -1,0 +1,17 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: rhods-model-mesh
+spec:
+  applications:
+    - kustomizeConfig:
+        overlays:
+          - odh-model-controller
+        repoRef:
+          name: manifests
+          path: model-mesh
+      name: model-mesh
+  repos:
+    - name: manifests
+      uri: file:///opt/manifests/odh-manifests.tar.gz
+  version: v1.0.0

--- a/kfdefs/rhods-model-mesh.yaml
+++ b/kfdefs/rhods-model-mesh.yaml
@@ -5,6 +5,19 @@ metadata:
 spec:
   applications:
     - kustomizeConfig:
+        parameters:
+        - name: odh-mm-rest-proxy
+          value: ${ODH_MM_REST_PROXY_IMAGE}
+        - name: odh-modelmesh-runtime-adapter
+          value: ${ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE}
+        - name: odh-modelmesh
+          value: ${ODH_MODELMESH_IMAGE}
+        - name: odh-openvino
+          value: ${ODH_OPENVINO_IMAGE}
+        - name: odh-modelmesh-controller
+          value: ${ODH_MODELMESH_CONTROLLER_IMAGE}
+        - name: odh-model-controller
+          value: ${ODH_MODEL_CONTROLLER_IMAGE}
         overlays:
           - odh-model-controller
         repoRef:

--- a/kfdefs/rhods-modelmesh-monitoring.yaml
+++ b/kfdefs/rhods-modelmesh-monitoring.yaml
@@ -1,0 +1,16 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: modelmesh-monitoring
+  namespace: redhat-ods-monitoring
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: modelmesh-monitoring
+    name: modelmesh-monitoring
+  repos:
+  - name: manifests
+    uri: file:///opt/manifests/odh-manifests.tar.gz
+  version: v1.20.0

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -473,6 +473,44 @@ data:
           regex: (.+):(\d+)
           target_label: __address__
           replacement: ${1}:8080
+    
+    - job_name: 'ODH Model Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(odh-model-controller-metrics-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'Modelmesh Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(modelmesh-controller)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
 
     - job_name: 'RHODS Metrics'
       honor_labels: true

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -141,6 +141,92 @@ data:
             instance: notebook-spawner
           record: probe_success:burnrate6h
 
+      - name: SLOs - ODH Model Controller
+        rules:
+        - expr: |
+            absent(up{job=~'ODH Model Controller'}) * 0 or vector(1)
+          labels:
+            instance: odh-model-controller
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[1d]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[1h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[2h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[30m]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[3d]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[5m]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[6h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate6h
+
+      - name: SLOs - Modelmesh Controller
+        rules:
+        - expr: |
+            absent(up{job=~'Modelmesh Controller'}) * 0 or vector(1)
+          labels:
+            instance: modelmesh-controller
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[1d]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[1h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[2h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[30m]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[3d]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[5m]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[6h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate6h
+
       - name: SLOs - RHODS Operator
         interval: 15m
         rules:
@@ -352,6 +438,79 @@ data:
           for: 3h
           labels:
             severity: warning
+    - alert: ODH Model Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: ODH Model Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate5m{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1h{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+      for: 2m
+      labels:
+        severity: critical
+    - alert: ODH Model Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: ODH Model Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate30m{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate6h{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+      for: 15m
+      labels:
+        severity: critical
+    - alert: ODH Model Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: ODH Model Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate2h{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1d{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+      for: 1h
+      labels:
+        severity: warning
+    - alert: Modelmesh Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: Modelmesh Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate5m{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1h{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+      for: 2m
+      labels:
+        severity: critical
+    - alert: Modelmesh Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: Modelmesh Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate30m{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate6h{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+      for: 15m
+      labels:
+        severity: critical
+    - alert: Modelmesh Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: Modelmesh Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate2h{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1d{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+      for: 1h
+      labels:
+        severity: warning  
+
 
       - name: RHODS Notebook controllers
         rules:

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -254,7 +254,6 @@ data:
 
   alerting.rules: |
     groups:
-
       - name: DeadManSnitch
         interval: 1m
         rules:
@@ -438,79 +437,78 @@ data:
           for: 3h
           labels:
             severity: warning
-    - alert: ODH Model Controller Probe Success Burn Rate
-      annotations:
-        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
-        summary: ODH Model Controller Probe Success Burn Rate
-      expr: |
-        sum(probe_success:burnrate5m{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
-        and
-        sum(probe_success:burnrate1h{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
-      for: 2m
-      labels:
-        severity: critical
-    - alert: ODH Model Controller Probe Success Burn Rate
-      annotations:
-        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
-        summary: ODH Model Controller Probe Success Burn Rate
-      expr: |
-        sum(probe_success:burnrate30m{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
-        and
-        sum(probe_success:burnrate6h{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
-      for: 15m
-      labels:
-        severity: critical
-    - alert: ODH Model Controller Probe Success Burn Rate
-      annotations:
-        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
-        summary: ODH Model Controller Probe Success Burn Rate
-      expr: |
-        sum(probe_success:burnrate2h{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
-        and
-        sum(probe_success:burnrate1d{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
-      for: 1h
-      labels:
-        severity: warning
-    - alert: Modelmesh Controller Probe Success Burn Rate
-      annotations:
-        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
-        summary: Modelmesh Controller Probe Success Burn Rate
-      expr: |
-        sum(probe_success:burnrate5m{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
-        and
-        sum(probe_success:burnrate1h{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
-      for: 2m
-      labels:
-        severity: critical
-    - alert: Modelmesh Controller Probe Success Burn Rate
-      annotations:
-        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
-        summary: Modelmesh Controller Probe Success Burn Rate
-      expr: |
-        sum(probe_success:burnrate30m{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
-        and
-        sum(probe_success:burnrate6h{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
-      for: 15m
-      labels:
-        severity: critical
-    - alert: Modelmesh Controller Probe Success Burn Rate
-      annotations:
-        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
-        summary: Modelmesh Controller Probe Success Burn Rate
-      expr: |
-        sum(probe_success:burnrate2h{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
-        and
-        sum(probe_success:burnrate1d{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
-      for: 1h
-      labels:
-        severity: warning  
-
+        - alert: ODH Model Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: ODH Model Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: ODH Model Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: ODH Model Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: ODH Model Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: ODH Model Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning
+        - alert: Modelmesh Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: Modelmesh Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: Modelmesh Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: Modelmesh Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: Modelmesh Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: Modelmesh Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning  
 
       - name: RHODS Notebook controllers
         rules:


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHODS-5242, https://issues.redhat.com/browse/RHODS-5243

Related PRs: 
1. https://github.com/red-hat-data-services/opendatahub-operator/pull/159
2. https://github.com/red-hat-data-services/odh-manifests/pull/246
3. https://gitlab.cee.redhat.com/data-hub/rhods-live-builder/-/merge_requests/58

Live build: quay.io/anishasthana/rhods-operator-live-catalog:1.20.2-5242

Steps to test:

1. `./setup.sh quay.io/anishasthana/rhods-operator-live-catalog:1.20.2-5242`
2. Wait for the modelmesh monitoring stack pods to come up
3. Clone https://github.com/opendatahub-io/modelmesh-serving/tree/main/quickstart.
4. Comment out lines 32 and 33.
5. `./quickstart.sh`. Wait for the script to finish runnning
7. Set up port forwarding for the new monitoring pod: `oc port-forward prometheus-rhods-model-monitoring-0 9090`
8. Connect to localhost:9090 on your browser. You will see the new target


<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6526150/200429926-c9d83dd7-8c5c-49ef-b859-99bc60c86b0c.png">

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/6526150/200430072-dee44a06-1cef-4f7c-bcdc-5bb8080f1d22.png">

