### PR TITLE
Add Kfdef and Prometheus configuration for Modelmesh monitoring

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -173,6 +173,19 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Uncomment when Data Science Pipelines kfdef is added
+# oc apply -n ${ODH_PROJECT} -f rhods-data-science-pipelines.yaml
+# if [ $? -ne 0 ]; then
+#   echo "ERROR: Attempt to create the Data Science Pipelines CR failed."
+#   exit 1
+# fi
+
+oc apply -n ${ODH_PROJECT} -f rhods-model-mesh.yaml
+if [ $? -ne 0 ]; then
+  echo "ERROR: Attempt to create the Model Mesh CR failed."
+  exit 1
+fi
+
 deadmanssnitch=$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-deadmanssnitch -o jsonpath='{.data.SNITCH_URL}'" 4 90 | tr -d "'"  | base64 --decode)
 
 if [ -z "$deadmanssnitch" ];then

--- a/kfdefs/rhods-model-mesh.yaml
+++ b/kfdefs/rhods-model-mesh.yaml
@@ -1,0 +1,17 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: rhods-model-mesh
+spec:
+  applications:
+    - kustomizeConfig:
+        overlays:
+          - odh-model-controller
+        repoRef:
+          name: manifests
+          path: model-mesh
+      name: model-mesh
+  repos:
+    - name: manifests
+      uri: file:///opt/manifests/odh-manifests.tar.gz
+  version: v1.0.0

--- a/kfdefs/rhods-model-mesh.yaml
+++ b/kfdefs/rhods-model-mesh.yaml
@@ -5,6 +5,19 @@ metadata:
 spec:
   applications:
     - kustomizeConfig:
+        parameters:
+        - name: odh-mm-rest-proxy
+          value: ${ODH_MM_REST_PROXY_IMAGE}
+        - name: odh-modelmesh-runtime-adapter
+          value: ${ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE}
+        - name: odh-modelmesh
+          value: ${ODH_MODELMESH_IMAGE}
+        - name: odh-openvino
+          value: ${ODH_OPENVINO_IMAGE}
+        - name: odh-modelmesh-controller
+          value: ${ODH_MODELMESH_CONTROLLER_IMAGE}
+        - name: odh-model-controller
+          value: ${ODH_MODEL_CONTROLLER_IMAGE}
         overlays:
           - odh-model-controller
         repoRef:

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -141,6 +141,92 @@ data:
             instance: notebook-spawner
           record: probe_success:burnrate6h
 
+      - name: SLOs - ODH Model Controller
+        rules:
+        - expr: |
+            absent(up{job=~'ODH Model Controller'}) * 0 or vector(1)
+          labels:
+            instance: odh-model-controller
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[1d]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[1h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[2h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[30m]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[3d]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[5m]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[6h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate6h
+
+      - name: SLOs - Modelmesh Controller
+        rules:
+        - expr: |
+            absent(up{job=~'Modelmesh Controller'}) * 0 or vector(1)
+          labels:
+            instance: modelmesh-controller
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[1d]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[1h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[2h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[30m]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[3d]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[5m]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[6h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate6h
+
       - name: SLOs - RHODS Operator
         interval: 15m
         rules:
@@ -352,6 +438,79 @@ data:
           for: 3h
           labels:
             severity: warning
+    - alert: ODH Model Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: ODH Model Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate5m{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1h{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+      for: 2m
+      labels:
+        severity: critical
+    - alert: ODH Model Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: ODH Model Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate30m{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate6h{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+      for: 15m
+      labels:
+        severity: critical
+    - alert: ODH Model Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: ODH Model Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate2h{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1d{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+      for: 1h
+      labels:
+        severity: warning
+    - alert: Modelmesh Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: Modelmesh Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate5m{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1h{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+      for: 2m
+      labels:
+        severity: critical
+    - alert: Modelmesh Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: Modelmesh Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate30m{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate6h{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+      for: 15m
+      labels:
+        severity: critical
+    - alert: Modelmesh Controller Probe Success Burn Rate
+      annotations:
+        message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+        triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+        summary: Modelmesh Controller Probe Success Burn Rate
+      expr: |
+        sum(probe_success:burnrate2h{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+        and
+        sum(probe_success:burnrate1d{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+      for: 1h
+      labels:
+        severity: warning  
+
 
       - name: Builds
         rules:

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -507,6 +507,44 @@ data:
           regex: (.+):(\d+)
           target_label: __address__
           replacement: ${1}:8080
+    
+    - job_name: 'ODH Model Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(odh-model-controller-metrics-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'Modelmesh Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(modelmesh-controller)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
 
     - job_name: 'RHODS Metrics'
       honor_labels: true


### PR DESCRIPTION
Signed-off-by: Ricardo Martinelli de Oliveira <rmartine@redhat.com>

## Description
Add the kfdef to deploy modelmesh, as well as the monitoring configuration for Prometheus

## How Has This Been Tested?
* Deploy RHODS
* Open Prometheus endpoint
* In the Status > Targets menu, you should see the following:
    * Modelmesh Controller (1/1 up)
    * ODH Model Controller (3/3 up)

## Merge criteria:
PR https://github.com/red-hat-data-services/odh-manifests/pull/255 must be merged before testing.

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-5433
- [X] The Jira story is acked.
- [ ] Live build image: 
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
