### PR TITLE
Sync the odh-dashboard CRD

### DIFF
--- a/odh-dashboard/crds/odh-dashboard-crd.yaml
+++ b/odh-dashboard/crds/odh-dashboard-crd.yaml
@@ -2,8 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: odhdashboardconfigs.opendatahub.io
-  labels:
-    opendatahub.io/dashboardcrd: "true"
 spec:
   group: opendatahub.io
   scope: Namespaced
@@ -90,6 +88,9 @@ spec:
                     notebookNamespace:
                       type: string
                     pvcSize:
+                      type: string
+                    gpuSetting:
+                      description: Configure how the GPU field works on the Jupyter tile. One of 'autodetect' (default, fetches for information), 'hidden' (remove the field) or a number-string (eg '5') to specify a hardcoded 0 to that number options
                       type: string
                     notebookTolerationSettings:
                       type: object


### PR DESCRIPTION
Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

## Description
Updates the `ODHDashboardConfig` CRD to match what is available in odh-manifests

## How Has This Been Tested?
Deployed odh-deployer image with this CRD patched in

## Merge criteria:
CRD is correct
odh-deployer creates the CRD with the new `gpuSettings` property added

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
