### PR TITLE
RHODS-4543 Updated GPU quick starts to work with getting-started-with-gpus repo

### DIFF
--- a/odh-dashboard/apps-managed-service/nvidia/gpu-enabled-notebook-quickstart.yaml
+++ b/odh-dashboard/apps-managed-service/nvidia/gpu-enabled-notebook-quickstart.yaml
@@ -10,36 +10,55 @@ spec:
   durationMinutes: 5
   icon: 'images/nvidia.svg'
   description: Install GPU add-on
+  prerequisites: [You have completed the "Installing and verifying NVIDIA GPU add-on" quick start.]
   introduction: |-
-    ### This quick start shows you how to run a JupyterHub Notebook that uses the available GPUs.
+    This quick start shows you how to run a notebook that uses a GPU available in your cluster.
   tasks:
-    - title: Import a JupyterHub Notebook into JupyterLab
+    - title: Import the notebook repository into Jupyter
       description: |-
-        Prerequisite: User must know how to spawn a Notebook with at least 1 GPU attached. Complete the "Installing and verifying NVIDIA GPU add-on" if not completed already.
+        ### Prerequisites
 
-        1. In the top navigation panel click **Git**
+        - You have launched a notebook server with at least 1 GPU attached. For help, run the "Installing and verifying NVIDIA GPU add-on" quick start.
+
+        ### Procedure
+
+        1. In Jupyter, click the **Git** menu.
         2. Click **Clone a repository**.
         3. Enter URL of the repository to be cloned : **https://github.com/rh-aiservices-bu/getting-started-with-gpus** and click **Clone**.
 
       review:
         instructions: |-
-          #### To verify you have installed the GPU add-on:
-          Can you see the "Getting started with GPUs" repository in the file navigation pane in JupyterHub?
+          Can you see a getting-started-with-gpus directory in the file navigation pane in Jupyter?
         failedTaskHelp: This task is not verified yet. Try the task again.
       summary:
-        success: You have successfully cloned the git repository and imported the notebook into JupyterHub.
-        failed: Ensure you have met the prerequisites for the GPU add on and try the steps again.
-    - title: Run the JupyterHub Notebook
+        success: You have successfully cloned the notebook repository into your notebook server environment.
+        failed: Ensure you have met the prerequisites for the GPU add-on and try the steps again.
+    - title: Run the "Using GPU resources with PyTorch" notebook
       description: |-
-        1. Double click the **torch-use-gpu.ipynb** file.
-        2. Run the notebook. Each step within the notebook is explained within the notebook itself. The notebook has steps to verify existence of a GPU, as well as use the GPU for creating a model.
+        1. Double click the **torch-use-gpu.ipynb** file to open the "Using GPU resources with PyTorch" notebook.
+        2. Read through and run each step in the notebook file to learn how to check for an available GPU and use the GPU to train a simple model. Detailed explanations of each step are provided in the notebook.
 
       review:
         instructions: |-
-          #### To verify that you have the available GPUs for use:
-          Can you run the **torch-use-gpu.ipynb** file?
-        failedTaskHelp: This task is not verified yet. Try the task again.
+          Were you able to run all steps in the **torch-use-gpu.ipynb** file?
+        failedTaskHelp: Ensure that you have at least one GPU node available in your cluster and then try the task again.
       summary:
-        success: You have successfully created a model while using a GPU.
+        success: You have successfully trained a model while using a GPU.
+        failed: Try the steps again.
+    - title: Run the "Loading and running a trained model with PyTorch" notebook
+      description: |-
+        1. Double click the **torch-test-model.ipynb** file to open the "Loading and running a trained model with PyTorch" notebook.
+        2. Read through and run each step in the notebook file to learn how to check for an available GPU and use it to run a trained model. Detailed explanations of each step are provided in the notebook.
+
+      review:
+        instructions: |-
+          Were you able to run the **torch-use-gpu.ipynb** file?
+        failedTaskHelp: Ensure that you have at least one GPU node available in your cluster and then try the task again.
+      summary:
+        success: You have successfully run a trained model while using a GPU.
         failed: Try the steps again.
   nextQuickStart: []
+  conclusion: >-
+    Congratulations!
+
+    You have successfully used a GPU to train and run a model.

--- a/odh-dashboard/apps-managed-service/nvidia/gpu-quickstart.yaml
+++ b/odh-dashboard/apps-managed-service/nvidia/gpu-quickstart.yaml
@@ -10,36 +10,51 @@ spec:
   durationMinutes: 5
   icon: 'images/nvidia.svg'
   description: Install GPU add-on
+  prerequisites: [Your cluster has at least one GPU node provisioned.]
   introduction: |-
-    ### This quick start shows you how to install the GPU add-on and verify that the JupyterHub spawner detects the available GPUs.
+    This quick start shows you how to install the GPU add-on and verify that the JupyterHub spawner detects the available GPUs.
   tasks:
     - title: Launch Red Hat Hybrid Cloud Console
       description: |-
+        Prerequisites:
+        
+        - Your cluster has at least one GPU node provisioned.
+
+        Procedure:
+
         1. Navigate to the Red Hat Hybrid Cloud Console in a new tab on your web browser.
-        2. On the left navigation menu select **OpenShift** -> **Clusters** and select the cluster you are working on.
-        3. From the Cluster Overview page, navigate to the **Add-ons** menu.
-        3. Install the **NVIDIA GPU Add-on**. (To install the add on the cluster must have GPU node(s) provisioned.)
+        2. Click **OpenShift** in the left navigation menu.
+        3. Click the name of the cluster you want to work with.
+        4. Click the **Add-ons** tab.
+        5. Locate the **NVIDIA GPU Add-on** card and click **Install**.
 
       review:
         instructions: |-
-          #### To verify you have installed the GPU add-on:
-          Can you see the add-on with the label **Installed** in the add-ons menu?
-        failedTaskHelp: This task is not verified yet. Try the task again.
+          Has the NVIDIA GPU Add-on card updated to show the **Installed** label?
+        failedTaskHelp: If the card has updated to show **Installing**, wait a little longer. Otherwise, try the task again.
       summary:
         success: You have installed the NVIDIA GPU Add-on.
-        failed: Ensure you have met the prerequisites for the GPU add on and try the steps again.
-    - title: Verify that the JupyterHub spawner sees the available GPUs
+        failed: Ensure you have met the prerequisites for the add-on and try the steps again.
+    - title: Verify that Red Hat OpenShift Data Science sees the available GPUs
       description: |-
-        1. Open the JupyterHub spawner from the Red Hat OpenShift Data Science dashboard.
-        2. In the **Deployment size** menu, click on the **Number of GPUs** dropdown and select the number of GPUs you want to use.
-        3. Launch a notebook server using the Pytorch notebook image.
+        Prerequisites:
+
+        - You have no notebook servers running in Red Hat OpenShift Data Science.
+        
+        1. Navigate to the Red Hat OpenShift Data Science dashboard.
+        2. Click **Launch** on the Jupyter card to open the **Start a notebook server** page.
+        2. Under **Deployment size**, set the **Number of GPUs** dropdown menu to the number of GPUs you want to use.
+        3. Launch a notebook server using the PyTorch notebook image.
 
       review:
         instructions: |-
-          #### To verify that you have the available GPUs for use:
-          Can you select the number of GPUS in the JupyterHub spawner?
-        failedTaskHelp: This task is not verified yet. Try the task again.
+          Can you select the number of GPUS?
+        failedTaskHelp: Ensure you have met the prerequisites for the add-on and try the steps again.
       summary:
-        success: Your server has started and the JupyterHub will automatically use the selected GPUs
-        failed: Try the steps again.
+        success: Your server has started and Jupyter will automatically use the selected GPUs
+        failed: Ensure you have met the prerequisites for the add-on and try the steps again.
   nextQuickStart: [gpu-enabled-notebook-quickstart]
+  conclusion: >-
+    Congratulations!
+
+    You have successfully installed the NVIDIA GPU Add-on and confirmed that your GPUs are visible.

--- a/odh-dashboard/apps-managed-service/nvidia/nvidia-app.yaml
+++ b/odh-dashboard/apps-managed-service/nvidia/nvidia-app.yaml
@@ -23,7 +23,7 @@ spec:
   enable:
     title: Enable NVIDIA GPU Add-on
     actionLabel: Enable
-    description: Clicking enable will add the NVIDIA GPU Add-on card to the Enabled page
+    description: Clicking enable adds the NVIDIA GPU Add-on card to the Enabled page
     linkPreface: |-
       Before enabling, be sure you have installed the NVIDIA GPU Add-on:
     link: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/enabling-gpu-support-in-openshift-data-science_user-mgmt


### PR DESCRIPTION
## Description
RHODS-4543 required updates to the NVIDIA GPU quick starts and the notebook files in the https://github.com/rh-aiservices-bu/getting-started-with-gpus/ repository. These changes ensure the quick start remains accurate to the notebook resources.

The following MR contained the changes to the notebook files: https://github.com/rh-aiservices-bu/getting-started-with-gpus/pull/1

## How Has This Been Tested?
Confirmed quick start format using the Patternfly Preview Quickstarts extension: https://marketplace.visualstudio.com/items?itemName=PatternFly.quickstarts-preview
Confirmed URLs work as expected.
Confirmed getting-started-with-gpus repo can be cloned by non-RH user.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4543
- [ ] The Jira story is acked.
- [x] Live build image: N/A
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
