### PR TITLE
Make odh-deployer compatible with self-managed

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -127,18 +127,6 @@ oc get catalogsource -n ${OPERATOR_NAMESPACE} addon-managed-odh-catalog &> /dev/
 # Apply isvs for dashboard
 oc::dashboard::apply::isvs
 
-# If a reader secret has been created, link it to the default SA
-# This is so that private images in quay.io/modh can be loaded into imagestreams
-READER_SECRET="addon-managed-odh-pullsecret"
-linkdefault=0
-oc get secret ${READER_SECRET} &> /dev/null || linkdefault=1
-if [ "$linkdefault" -eq 0 ]; then
-    echo Linking ${READER_SECRET} to default SA
-    oc secret link default ${READER_SECRET} --for=pull -n ${ODH_PROJECT}
-else
-    echo no ${READER_SECRET} secret, default SA unchanged
-fi
-
 # Give dedicated-admins group CRUD access to ConfigMaps, Secrets, ImageStreams, Builds and BuildConfigs in select namespaces
 for target_project in ${ODH_PROJECT} ${ODH_NOTEBOOK_PROJECT}; do
   oc apply -n $target_project -f rhods-osd-configs.yaml

--- a/deploy.sh
+++ b/deploy.sh
@@ -120,9 +120,9 @@ oc label namespace $ODH_MONITORING_PROJECT  $NAMESPACE_LABEL --overwrite=true ||
 # If rhodsquickstart CRD is found, delete it. Note: Remove this code in 1.19
 oc delete crd rhodsquickstarts.console.openshift.io 2>/dev/null || echo "INFO: Unable to delete Rhodsquickstart CRD"
 
-# Set RHODS_SELF_MANAGED to 0, if catalogsource not found.
-RHODS_SELF_MANAGED=1
-oc get catalogsource -n openshift-marketplace self-managed-rhods &> /dev/null || RHODS_SELF_MANAGED=0
+# Set RHODS_SELF_MANAGED to 1, if addon installation not found.
+RHODS_SELF_MANAGED=0
+oc get catalogsource -n ${OPERATOR_NAMESPACE} addon-managed-odh-catalog &> /dev/null || RHODS_SELF_MANAGED=1
 
 # Apply isvs for dashboard
 oc::dashboard::apply::isvs

--- a/deploy.sh
+++ b/deploy.sh
@@ -122,7 +122,7 @@ oc delete crd rhodsquickstarts.console.openshift.io 2>/dev/null || echo "INFO: U
 
 # Set RHODS_SELF_MANAGED to 1, if addon installation not found.
 RHODS_SELF_MANAGED=0
-oc get catalogsource -n ${OPERATOR_NAMESPACE} addon-managed-odh-catalog &> /dev/null || RHODS_SELF_MANAGED=1
+oc get catalogsource -n ${ODH_OPERATOR_PROJECT} addon-managed-odh-catalog || RHODS_SELF_MANAGED=1
 
 # Apply isvs for dashboard
 oc::dashboard::apply::isvs
@@ -162,125 +162,136 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-kind="secret"
-resource="anaconda-ce-access"
-
 if oc::object::safe::to::apply secret anaconda-ce-access; then
   oc apply -n ${ODH_PROJECT} -f partners/anaconda/anaconda-ce-access.yaml
 else
   echo "The Anaconda base secret (secret/anaconda-ce-access) has been modified. Skipping apply."
 fi
 
-# Give dedicated-admins group CRUD access to ConfigMaps, Secrets, ImageStreams, Builds and BuildConfigs in select namespaces
-for target_project in ${ODH_PROJECT} ${ODH_NOTEBOOK_PROJECT}; do
-  oc apply -n $target_project -f rhods-osd-configs.yaml
-  if [ $? -ne 0 ]; then
-    echo "ERROR: Attempt to create the RBAC policy for dedicated admins group in $target_project failed."
-    exit 1
+# Apply specific configuration for OSD environments
+if [ "$RHODS_SELF_MANAGED" -eq 0 ]; then
+
+  echo "INFO: Applying specific configuration for OSD environments."
+
+  # Give dedicated-admins group CRUD access to ConfigMaps, Secrets, ImageStreams, Builds and BuildConfigs in select namespaces
+  for target_project in ${ODH_PROJECT} ${ODH_NOTEBOOK_PROJECT}; do
+    oc apply -n $target_project -f rhods-osd-configs.yaml
+    if [ $? -ne 0 ]; then
+      echo "ERROR: Attempt to create the RBAC policy for dedicated admins group in $target_project failed."
+      exit 1
+    fi
+  done
+
+  # Configure Dead Man's Snitch alerting
+  deadmanssnitch=$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-deadmanssnitch -o jsonpath='{.data.SNITCH_URL}'" 4 90 | tr -d "'"  | base64 --decode)
+  if [ -z "$deadmanssnitch" ];then
+      echo "ERROR: Dead Man Snitch secret does not exist."
+      exit 1
   fi
-done
+  sed -i "s#<snitch_url>#$deadmanssnitch#g" monitoring/prometheus/prometheus-configs.yaml
 
-deadmanssnitch=$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-deadmanssnitch -o jsonpath='{.data.SNITCH_URL}'" 4 90 | tr -d "'"  | base64 --decode)
+  # Configure PagerDuty alerting
+  redhat_rhods_pagerduty=$(oc::wait::object::availability "oc get secret redhat-rhods-pagerduty -n $ODH_MONITORING_PROJECT" 5 60 )
+  if [ -z "$redhat_rhods_pagerduty" ];then
+      echo "ERROR: Pagerduty secret does not exist."
+      exit 1
+  fi
+  pagerduty_service_token=$(oc::wait::object::availability "oc get secret redhat-rhods-pagerduty -n $ODH_MONITORING_PROJECT -o jsonpath='{.data.PAGERDUTY_KEY}'" 5 10)
+  pagerduty_service_token=$(echo -ne "$pagerduty_service_token" | tr -d "'" | base64 --decode)
+  sed -i "s/<pagerduty_token>/$pagerduty_service_token/g" monitoring/prometheus/prometheus-configs.yaml
 
-if [ -z "$deadmanssnitch" ];then
-    echo "ERROR: Dead Man Snitch secret does not exist."
-    exit 1
+  # Configure SMTP alerting
+  redhat_rhods_smtp=$(oc::wait::object::availability "oc get secret redhat-rhods-smtp -n $ODH_MONITORING_PROJECT" 5 60 )
+  if [ -z "$redhat_rhods_smtp" ];then
+      echo "ERROR: SMTP secret does not exist."
+      exit 1
+  fi
+  sed -i "s/<smtp_host>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.host}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+  sed -i "s/<smtp_port>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.port}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+  sed -i "s/<smtp_username>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.username}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+  sed -i "s/<smtp_password>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.password}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+
+  # Configure the SMTP destination email
+  addon_managed_odh_parameter=$(oc::wait::object::availability "oc get secret addon-managed-odh-parameters -n $ODH_OPERATOR_PROJECT" 5 60 )
+  if [ -z "$addon_managed_odh_parameter" ];then
+      echo "ERROR: Addon managed odh parameter secret does not exist."
+      exit 1
+  fi
+  sed -i "s/<user_emails>/$(oc::wait::object::availability "oc get secret -n $ODH_OPERATOR_PROJECT addon-managed-odh-parameters -o jsonpath='{.data.notification-email}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+
+  # Configure the SMTP sender email
+  if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"devshift.org".* ]]; then
+    sed -i "s/redhat-openshift-alert@devshift.net/redhat-openshift-alert@rhmw.io/g" monitoring/prometheus/prometheus-configs.yaml
+  fi
+
+  if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"aisrhods".* ]]; then
+    echo "Cluster is for RHODS engineering or test purposes. Disabling SRE alerting."
+    sed -i "s/receiver: PagerDuty/receiver: alerts-sink/g" monitoring/prometheus/prometheus-configs.yaml
+  else
+    echo "Cluster is not for RHODS engineering or test purposes."
+  fi
+
+# Apply specific configuration for self-managed environments
+else
+    echo "INFO: Applying specific configuration for self-managed environments."
+
+    # Disable Dead Man's Snitch alerting
+    sed -i "s/<snitch_url>/http:\/\/localhost:80/g" monitoring/prometheus/prometheus-configs.yaml
+    sed -i "s/receiver: deadman-snitch/receiver: alerts-sink/g" monitoring/prometheus/prometheus-configs.yaml
+
+    # Disable PagerDuty alerting
+    sed -i "s/receiver: PagerDuty/receiver: alerts-sink/g" monitoring/prometheus/prometheus-configs.yaml
+
+    # Disable SMTP alerting
+    sed -i "s/<user_emails>/rhods@noreply/g" monitoring/prometheus/prometheus-configs.yaml
+    sed -i "s/<smtp_host>/localhost/g" monitoring/prometheus/prometheus-configs.yaml
+    sed -i "s/<smtp_port>/587/g" monitoring/prometheus/prometheus-configs.yaml
+    sed -i "s/<smtp_username>/rhods/g" monitoring/prometheus/prometheus-configs.yaml
+    sed -i "s/<smtp_password>/rhods/g" monitoring/prometheus/prometheus-configs.yaml
+    sed -i "s/receiver: user-notifications/receiver: alerts-sink/g" monitoring/prometheus/prometheus-configs.yaml
 fi
 
-sed -i "s#<snitch_url>#$deadmanssnitch#g" monitoring/prometheus/prometheus-configs.yaml
-
-sed -i "s/<prometheus_proxy_secret>/$(openssl rand -hex 32)/g" monitoring/prometheus/prometheus-secrets.yaml
-sed -i "s/<alertmanager_proxy_secret>/$(openssl rand -hex 32)/g" monitoring/prometheus/prometheus-secrets.yaml
-oc create -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus-secrets.yaml || echo "INFO: Prometheus session secrets already exist."
-
+# Configure Prometheus
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/alertmanager-svc.yaml
-
 alertmanager_host=$(oc::wait::object::availability "oc get route alertmanager -n $ODH_MONITORING_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
-
-# Check if pagerduty secret exists, if not, exit installation
-
-redhat_rhods_pagerduty=$(oc::wait::object::availability "oc get secret redhat-rhods-pagerduty -n $ODH_MONITORING_PROJECT" 5 60 )
-
-if [ -z "$redhat_rhods_pagerduty" ];then
-    echo "ERROR: Pagerduty secret does not exist."
-    exit 1
-fi
-
-pagerduty_service_token=$(oc::wait::object::availability "oc get secret redhat-rhods-pagerduty -n $ODH_MONITORING_PROJECT -o jsonpath='{.data.PAGERDUTY_KEY}'" 5 10)
-pagerduty_service_token=$(echo -ne "$pagerduty_service_token" | tr -d "'" | base64 --decode)
-
-oc apply -f monitoring/rhods-dashboard-route.yaml -n $ODH_PROJECT
-
-
-rhods_dashboard_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
-notebook_spawner_host="notebook-controller-service.$ODH_PROJECT.svc:8080\/metrics,odh-notebook-controller-service.$ODH_PROJECT.svc:8080\/metrics"
-
-sed -i "s/<rhods_dashboard_host>/$rhods_dashboard_host/g" monitoring/prometheus/prometheus-configs.yaml
-sed -i "s/<notebook_spawner_host>/$notebook_spawner_host/g" monitoring/prometheus/prometheus-configs.yaml
-sed -i "s/<pagerduty_token>/$pagerduty_service_token/g" monitoring/prometheus/prometheus-configs.yaml
 sed -i "s/<set_alertmanager_host>/$alertmanager_host/g" monitoring/prometheus/prometheus.yaml
 
-# Check if smtp secret exists, exit if it doesn't
-redhat_rhods_smtp=$(oc::wait::object::availability "oc get secret redhat-rhods-smtp -n $ODH_MONITORING_PROJECT" 5 60 )
+sed -i "s/<alertmanager_proxy_secret>/$(openssl rand -hex 32)/g" monitoring/prometheus/prometheus-secrets.yaml
 
-if [ -z "$redhat_rhods_smtp" ];then
-    echo "ERROR: SMTP secret does not exist."
-    exit 1
-fi
+sed -i "s/<prometheus_proxy_secret>/$(openssl rand -hex 32)/g" monitoring/prometheus/prometheus-secrets.yaml
+oc create -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus-secrets.yaml || echo "INFO: Prometheus session secrets already exist."
 
-# Check if addon parameter for mail secret exists, exit if it doesn't
+oc apply -f monitoring/rhods-dashboard-route.yaml -n $ODH_PROJECT
+rhods_dashboard_host=$(oc::wait::object::availability "oc get route rhods-dashboard -n $ODH_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
+sed -i "s/<rhods_dashboard_host>/$rhods_dashboard_host/g" monitoring/prometheus/prometheus-configs.yaml
 
-addon_managed_odh_parameter=$(oc::wait::object::availability "oc get secret addon-managed-odh-parameters -n $ODH_OPERATOR_PROJECT" 5 60 )
+notebook_spawner_host="notebook-controller-service.$ODH_PROJECT.svc:8080\/metrics,odh-notebook-controller-service.$ODH_PROJECT.svc:8080\/metrics"
+sed -i "s/<notebook_spawner_host>/$notebook_spawner_host/g" monitoring/prometheus/prometheus-configs.yaml
 
-if [ -z "$addon_managed_odh_parameter" ];then
-    echo "ERROR: Addon managed odh parameter secret does not exist."
-    exit 1
-fi
+oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus-configs.yaml
 
-sed -i "s/<smtp_host>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.host}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
-sed -i "s/<smtp_port>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.port}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
-sed -i "s/<smtp_username>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.username}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
-sed -i "s/<smtp_password>/$(oc::wait::object::availability "oc get secret -n $ODH_MONITORING_PROJECT redhat-rhods-smtp -o jsonpath='{.data.password}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+alertmanager_config=$(oc get cm alertmanager -n $ODH_MONITORING_PROJECT -o jsonpath='{.data.alertmanager\.yml}' | openssl dgst -binary -sha256 | openssl base64)
+sed -i "s#<alertmanager_config_hash>#$alertmanager_config#g" monitoring/prometheus/prometheus.yaml
 
-sed -i "s/<user_emails>/$(oc::wait::object::availability "oc get secret -n $ODH_OPERATOR_PROJECT addon-managed-odh-parameters -o jsonpath='{.data.notification-email}'" 2 30 | tr -d "'"  | base64 --decode)/g" monitoring/prometheus/prometheus-configs.yaml
+prometheus_config=$(oc get cm prometheus -n $ODH_MONITORING_PROJECT -o jsonpath='{.data}' | openssl dgst -binary -sha256 | openssl base64)
+sed -i "s#<prometheus_config_hash>#$prometheus_config#g" monitoring/prometheus/prometheus.yaml
+oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus.yaml
 
+sed -i "s#<odh_monitoring_project>#$ODH_MONITORING_PROJECT#g" monitoring/prometheus/prometheus-viewer-rolebinding.yaml
+oc apply -n $ODH_PROJECT -f monitoring/prometheus/prometheus-viewer-rolebinding.yaml
+
+# Configure Blackbox exporter
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/blackbox-exporter-common.yaml
 
-if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"redhat.com".* ]]
-then
+if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"redhat.com".* ]]; then
   oc apply -f monitoring/prometheus/blackbox-exporter-internal.yaml -n $ODH_MONITORING_PROJECT
 else
   oc apply -f monitoring/prometheus/blackbox-exporter-external.yaml -n $ODH_MONITORING_PROJECT
 fi
 
-if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"devshift.org".* ]]
-then
-  sed -i "s/redhat-openshift-alert@devshift.net/redhat-openshift-alert@rhmw.io/g" monitoring/prometheus/prometheus-configs.yaml
-fi
-
-if [[ "$(oc get route -n openshift-console console --template={{.spec.host}})" =~ .*"aisrhods".* ]]
-then
-  echo "Cluster is for RHODS engineering or test purposes. Disabling SRE alerting."
-  sed -i "s/receiver: PagerDuty/receiver: alerts-sink/g" monitoring/prometheus/prometheus-configs.yaml
-else
-  echo "Cluster is not for RHODS engineering or test purposes."
-fi
-
-oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus-configs.yaml
-
-prometheus_config=$(oc get cm prometheus -n $ODH_MONITORING_PROJECT -o jsonpath='{.data}' | openssl dgst -binary -sha256 | openssl base64)
-alertmanager_config=$(oc get cm alertmanager -n $ODH_MONITORING_PROJECT -o jsonpath='{.data.alertmanager\.yml}' | openssl dgst -binary -sha256 | openssl base64)
-
-sed -i "s#<prometheus_config_hash>#$prometheus_config#g" monitoring/prometheus/prometheus.yaml
-sed -i "s#<alertmanager_config_hash>#$alertmanager_config#g" monitoring/prometheus/prometheus.yaml
-sed -i "s#<odh_monitoring_project>#$ODH_MONITORING_PROJECT#g" monitoring/prometheus/prometheus-viewer-rolebinding.yaml
-
-oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/prometheus.yaml
-oc apply -n $ODH_MONITORING_PROJECT -f monitoring/grafana/grafana-sa.yaml
-oc apply -n $ODH_PROJECT -f monitoring/prometheus/prometheus-viewer-rolebinding.yaml
-
-
+# Configure Grafana
 prometheus_route=$(oc::wait::object::availability "oc get route prometheus -n $ODH_MONITORING_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")
+oc apply -n $ODH_MONITORING_PROJECT -f monitoring/grafana/grafana-sa.yaml
 grafana_token=$(oc::wait::object::availability "oc sa get-token grafana -n $ODH_MONITORING_PROJECT" 2 30)
 grafana_proxy_secret=$(oc get -n $ODH_MONITORING_PROJECT secret grafana-proxy-config -o jsonpath='{.data.session_secret}') && returncode=$? || returncode=$?
 
@@ -346,6 +357,7 @@ ADMIN_GROUPS="dedicated-admins"
 
 if [ "$RHODS_SELF_MANAGED" -eq 1 ]; then
   ADMIN_GROUPS="rhods-admins"
+  oc adm groups new ${ADMIN_GROUPS} || echo "rhods-admins group already exists"
 fi
 sed -i "s|<admin_groups>|$ADMIN_GROUPS|g" odh-dashboard/configs/odh-dashboard-config.yaml
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not fail if OSD dependencies (Dead Man's Snitch, PagerDuty and SMTP) are not met when RHODS is installed on a self-managed environment.

## How Has This Been Tested?
Install RHODS on a self-managed environment (e.g. PSI) using the following commands:

```shell
$ oc create ns redhat-ods-operator
$ oc config set-context --current=true --namespace=redhat-ods-operator

$ cat <<EOF | oc apply -f -
---
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhods-catalog-dev
  namespace: openshift-marketplace
spec:
  displayName: Red Hat OpenShift Data Science
  publisher: RHODS Development Catalog
  image: quay.io/modh/rhods-operator-live-catalog:1.20.0-rhods-5595
  sourceType: grpc

---
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: rhods-operator-dev
  namespace: redhat-ods-operator

---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: rhods-operator-dev
  namespace: redhat-ods-operator
spec:
  name: rhods-operator
  channel: stable
  source: rhods-catalog-dev
  sourceNamespace: openshift-marketplace
EOF
```
Wait until RHODS is deployed and running:

```shell
$ oc get csv -n openshift-marketplace
NAME                               DISPLAY                          VERSION             REPLACES                   PHASE
rhods-operator.1.20.0-rhods-5595   Red Hat OpenShift Data Science   1.20.0-rhods-5595   rhods-operator.1.19.0-14   Succeeded

$ oc get og -n redhat-ods-operator
NAME                 AGE
rhods-operator-dev   4m45s

$ oc get sub -n redhat-ods-operator
NAME                 PACKAGE          SOURCE              CHANNEL
rhods-operator-dev   rhods-operator   rhods-catalog-dev   stable

$ oc get pods -n redhat-ods-operator
NAME                             READY   STATUS    RESTARTS   AGE
rhods-operator-785546cbd-ltzqf   1/1     Running   0          4m17s

$ oc get pods -n redhat-ods-applications
NAME                                               READY   STATUS    RESTARTS   AGE
notebook-controller-deployment-5ffdbb78c6-rwwnh    1/1     Running   0          105s
odh-notebook-controller-manager-5bb8dff6b7-mbs48   1/1     Running   0          104s
rhods-dashboard-57b6fb8c89-4vzgb                   2/2     Running   0          90s
rhods-dashboard-57b6fb8c89-667nl                   2/2     Running   0          90s
rhods-dashboard-57b6fb8c89-6d2lc                   2/2     Running   0          90s
rhods-dashboard-57b6fb8c89-qfpdl                   2/2     Running   0          90s
rhods-dashboard-57b6fb8c89-tmt6s                   2/2     Running   0          90s

$ oc get pods -n redhat-ods-monitoring
NAME                                 READY   STATUS    RESTARTS   AGE
blackbox-exporter-75b66d54df-wgczf   2/2     Running   0          3m14s
grafana-6d74d684d8-2db6p             2/2     Running   0          3m3s
grafana-6d74d684d8-2gchr             2/2     Running   0          3m3s
prometheus-dd58cc67b-9xwqh           4/4     Running   0          3m19s
No resources found in rhods-notebooks namespace.
```


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5595
- [x] Live build image: quay.io/modh/rhods-operator-live-catalog:1.20.0-[rhods-5595](https://issues.redhat.com//browse/rhods-5595)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
