### PR TITLE
Add modelmesh cred secrets.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN tar -C /usr/local/bin -xvf $TMPDIR/oc.tar.gz && \
 
 COPY deploy.sh $HOME
 ADD kfdefs $HOME/kfdefs
+ADD model-mesh $HOME/model-mesh
 ADD monitoring $HOME/monitoring
 ADD consolelink $HOME/consolelink
 ADD partners $HOME/partners
@@ -33,6 +34,7 @@ ADD odh-dashboard $HOME/odh-dashboard
 
 RUN chmod 755 $HOME/deploy.sh && \
     chmod 644 -R $HOME/kfdefs && \
+    chmod 644 -R $HOME/model-mesh && \
     chmod 644 -R $HOME/monitoring && \
     chmod 644 -R $HOME/network && \
     chmod 644 -R $HOME/odh-dashboard && \

--- a/deploy.sh
+++ b/deploy.sh
@@ -272,6 +272,13 @@ else
     sed -i "s/receiver: user-notifications/receiver: alerts-sink/g" monitoring/prometheus/prometheus-configs.yaml
 fi
 
+# Configure Etcd Auth
+ETC_ROOT_PSW=$(openssl rand -hex 32)
+sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" model-mesh/etcd-secrets.yaml
+sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" model-mesh/etcd-users.yaml
+oc create -n ${ODH_PROJECT} -f model-mesh/etcd-secrets.yaml || echo "WARN: Model Mesh serving etcd connection secret was not created successfully."
+oc create -n ${ODH_PROJECT} -f model-mesh/etcd-users.yaml || echo "WARN: Etcd user secret was not created successfully."
+
 # Configure Prometheus
 oc apply -n $ODH_MONITORING_PROJECT -f monitoring/prometheus/alertmanager-svc.yaml
 alertmanager_host=$(oc::wait::object::availability "oc get route alertmanager -n $ODH_MONITORING_PROJECT -o jsonpath='{.spec.host}'" 2 30 | tr -d "'")

--- a/model-mesh/etcd-secrets.yaml
+++ b/model-mesh/etcd-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: model-serving-etcd
+  namespace: redhat-ods-applications
+stringData:
+  etcd_connection: |
+    {
+      "endpoints": "http://etcd:2379",
+      "root_prefix": "modelmesh-serving",
+      "userid": "root",
+      "password": "<etcd_password>"
+    }

--- a/model-mesh/etcd-users.yaml
+++ b/model-mesh/etcd-users.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-passwords
+  namespace: redhat-ods-applications
+stringData:
+  root: <etcd_password>


### PR DESCRIPTION
## Description
Add auth to etcd.

Part of: 
* https://github.com/red-hat-data-services/odh-manifests/pull/272
* https://gitlab.cee.redhat.com/data-hub/rhods-live-builder/-/merge_requests/100

## Testing instructions: 
1. ./setup.sh quay.io/hukhan/rhods-operator-live-catalog:1.20.1-5451
2. Confirm that the following secrets are created by the odh-deployer: 

```bash
oc -n redhat-ods-applications get secret model-serving-etcd -o jsonpath='{.data.etcd_connection}' | base64 -d
oc -n redhat-ods-applications get secret etcd-passwords -o jsonpath='{.data.root}' | base64 -d
```
The passwords in both secrets should match. One is used by etcd to create the root user, the other is used by MM to access etcd as this same user.

3. Wait for the modelmesh monitoring stack pods to come up
4. Clone https://github.com/opendatahub-io/modelmesh-serving/tree/main/quickstart.
5. Comment out lines 32 and 33.
6. ./quickstart.sh. Wait for the script to finish runnning
7. Test MM infer route to confirm it works. 
8. Update the value of `password` field in secret `model-serving-etcd` in `redhat-ods-applications`, so that it is different than the one in the secret `etcd-passwords`. Recreate the serving run time: 

```bash
oc delete -f openvino-inference-service.yaml -f openvino-serving-runtime.yaml 
./quickstart.sh
```
10. The modelmesh runtime pods will fail to boot up because they have the incorrect credentials to etcd.


## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5451
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
