### PR TITLE
Add RELATED_IMAGE_ prefix to env images

### DIFF
--- a/kfdefs/rhods-dashboard.yaml
+++ b/kfdefs/rhods-dashboard.yaml
@@ -12,7 +12,7 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: odh-dashboard-image
-        value: ${ODH_DASHBOARD_IMAGE}
+        value: ${RELATED_IMAGE_ODH_DASHBOARD_IMAGE}
       overlays:
         - authentication
       repoRef:

--- a/kfdefs/rhods-model-mesh.yaml
+++ b/kfdefs/rhods-model-mesh.yaml
@@ -7,17 +7,17 @@ spec:
     - kustomizeConfig:
         parameters:
         - name: odh-mm-rest-proxy
-          value: ${ODH_MM_REST_PROXY_IMAGE}
+          value: ${RELATED_IMAGE_ODH_MM_REST_PROXY_IMAGE}
         - name: odh-modelmesh-runtime-adapter
-          value: ${ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE}
+          value: ${RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE}
         - name: odh-modelmesh
-          value: ${ODH_MODELMESH_IMAGE}
+          value: ${RELATED_IMAGE_ODH_MODELMESH_IMAGE}
         - name: odh-openvino
-          value: ${ODH_OPENVINO_IMAGE}
+          value: ${RELATED_IMAGE_ODH_OPENVINO_IMAGE}
         - name: odh-modelmesh-controller
-          value: ${ODH_MODELMESH_CONTROLLER_IMAGE}
+          value: ${RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE}
         - name: odh-model-controller
-          value: ${ODH_MODEL_CONTROLLER_IMAGE}
+          value: ${RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE}
         overlays:
           - odh-model-controller
         repoRef:

--- a/kfdefs/rhods-nbc.yaml
+++ b/kfdefs/rhods-nbc.yaml
@@ -19,9 +19,9 @@ spec:
   - kustomizeConfig:
       parameters:
       - name: odh-notebook-controller-image
-        value: ${ODH_NOTEBOOK_CONTROLLER_IMAGE}
+        value: ${RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE}
       - name: odh-kf-notebook-controller-image
-        value: ${ODH_KF_NOTEBOOK_CONTROLLER_IMAGE}
+        value: ${RELATED_IMAGE_ODH_KF_NOTEBOOK_CONTROLLER_IMAGE}
       repoRef:
         name: manifests
         path: odh-notebook-controller


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
OSBS requires operator images to start with the `RELATED_IMAGE_` prefix to [pinning pullspecs for related image](https://osbs.readthedocs.io/en/latest/users.html#pinning-pullspecs-for-related-images).

## How Has This Been Tested?
Install the following live build:

```shell
$ ./setup.sh -t operator -i quay.io/modh/rhods-operator-live-catalog:1.20.0-related-images
```

Verify RHODS is installed correctly:

```shell
NAME                                   DISPLAY                          VERSION                 REPLACES                   PHASE
rhods-operator.1.20.0-related-images   Red Hat OpenShift Data Science   1.20.0-related-images   rhods-operator.1.19.0-19   Succeeded
NAME                 AGE
rhods-operator-dev   6m54s
NAME                 PACKAGE          SOURCE              CHANNEL
rhods-operator-dev   rhods-operator   rhods-catalog-dev   beta
NAME                                                              READY   STATUS      RESTARTS   AGE
a9e85e59c7de3cc0ea479800dba3a593220627e978bec5e5f48ab1c4cel8ktd   0/1     Completed   0          6m44s
rhods-catalog-dev-nmwsp                                           1/1     Running     0          6m55s
rhods-operator-6c64d8b94c-kpdp5                                   1/1     Running     0          6m31s
No resources found in redhat-ods-applications namespace.
NAME                                               READY   STATUS    RESTARTS   AGE
notebook-controller-deployment-d85b5cb45-85s2v     1/1     Running   0          4m3s
odh-notebook-controller-manager-65554796bb-pt5pg   1/1     Running   0          4m3s
rhods-dashboard-85bbb778d8-7tbsm                   2/2     Running   0          3m50s
rhods-dashboard-85bbb778d8-924f6                   2/2     Running   0          3m50s
rhods-dashboard-85bbb778d8-fqc9l                   2/2     Running   0          3m50s
rhods-dashboard-85bbb778d8-g65xq                   2/2     Running   0          3m50s
rhods-dashboard-85bbb778d8-t2bwc                   2/2     Running   0          3m50s
NAME                                 READY   STATUS    RESTARTS   AGE
blackbox-exporter-75b66d54df-4wgxh   2/2     Running   0          5m21s
prometheus-7bcc5cc656-jj2tq          4/4     Running   0          5m25s
No resources found in rhods-notebooks namespace.
```

