### PR TITLE
Update Pod security policy for RHODS namespaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ADD consolelink $HOME/consolelink
 ADD partners $HOME/partners
 ADD network $HOME/network
 ADD odh-dashboard $HOME/odh-dashboard
+ADD pod-security-rbac $HOME/pod-security-rbac
 
 RUN chmod 755 $HOME/deploy.sh && \
     chmod 644 -R $HOME/kfdefs && \
@@ -38,6 +39,7 @@ RUN chmod 755 $HOME/deploy.sh && \
     chmod 644 -R $HOME/monitoring && \
     chmod 644 -R $HOME/network && \
     chmod 644 -R $HOME/odh-dashboard && \
+    chmod 644 -R $HOME/pod-security-rbac && \
     chown 1001:0 -R $HOME &&\
     chmod ug+rwx -R $HOME
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -106,9 +106,11 @@ ODH_MONITORING_PROJECT=${ODH_MONITORING_NAMESPACE:-"redhat-ods-monitoring"}
 ODH_NOTEBOOK_PROJECT=${ODH_NOTEBOOK_NAMESPACE:-"rhods-notebooks"}
 ODH_OPERATOR_PROJECT=${OPERATOR_NAMESPACE:-"redhat-ods-operator"}
 NAMESPACE_LABEL="opendatahub.io/generated-namespace=true"
+POD_SECURITY_LABEL="pod-security.kubernetes.io/enforce=baseline"
 
 oc new-project ${ODH_PROJECT} || echo "INFO: ${ODH_PROJECT} project already exists."
 oc label namespace $ODH_PROJECT  $NAMESPACE_LABEL --overwrite=true || echo "INFO: ${NAMESPACE_LABEL} label already exists."
+oc label namespace $ODH_PROJECT  $POD_SECURITY_LABEL --overwrite=true || echo "INFO: ${POD_SECURITY_LABEL} label already exists."
 
 oc new-project ${ODH_NOTEBOOK_PROJECT} || echo "INFO: ${ODH_NOTEBOOK_PROJECT} project already exists."
 oc label namespace $ODH_NOTEBOOK_PROJECT  $NAMESPACE_LABEL --overwrite=true || echo "INFO: ${NAMESPACE_LABEL} label already exists."
@@ -116,7 +118,11 @@ oc label namespace $ODH_NOTEBOOK_PROJECT  $NAMESPACE_LABEL --overwrite=true || e
 oc new-project $ODH_MONITORING_PROJECT || echo "INFO: $ODH_MONITORING_PROJECT project already exists."
 oc label namespace $ODH_MONITORING_PROJECT openshift.io/cluster-monitoring=true --overwrite=true
 oc label namespace $ODH_MONITORING_PROJECT  $NAMESPACE_LABEL --overwrite=true || echo "INFO: ${NAMESPACE_LABEL} label already exists."
+oc label namespace $ODH_MONITORING_PROJECT  $POD_SECURITY_LABEL --overwrite=true || echo "INFO: ${POD_SECURITY_LABEL} label already exists."
 
+# Create Rolebinding for baseline permissions
+oc apply -n ${ODH_PROJECT} -f pod-security-rbac/applications-ns-rolebinding.yaml
+oc apply -n ${ODH_MONITORING_PROJECT} -f pod-security-rbac/monitoring-ns-rolebinding.yaml
 # If rhodsquickstart CRD is found, delete it. Note: Remove this code in 1.19
 oc delete crd rhodsquickstarts.console.openshift.io 2>/dev/null || echo "INFO: Unable to delete Rhodsquickstart CRD"
 

--- a/pod-security-rbac/applications-ns-rolebinding.yaml
+++ b/pod-security-rbac/applications-ns-rolebinding.yaml
@@ -1,0 +1,25 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: rhods-applications-scc
+subjects:
+# Add all application SA separately, since some of them require the restricted permissions
+ - kind: Group
+   apiGroup: rbac.authorization.k8s.io
+   name: 'system:serviceaccounts:redhat-ods-applications:modelmesh-controller'
+ - kind: Group
+   apiGroup: rbac.authorization.k8s.io
+   name: 'system:serviceaccounts:redhat-ods-applications:notebook-controller-service-account'
+ - kind: Group
+   apiGroup: rbac.authorization.k8s.io
+   name: 'system:serviceaccounts:redhat-ods-applications:odh-model-controller'
+ - kind: Group
+   apiGroup: rbac.authorization.k8s.io
+   name: 'system:serviceaccounts:redhat-ods-applications:rhods-dashboard'
+ - kind: Group
+   apiGroup: rbac.authorization.k8s.io
+   name: 'system:serviceaccounts:redhat-ods-applications:modelmesh'
+roleRef:
+ apiGroup: rbac.authorization.k8s.io
+ kind: ClusterRole
+ name: 'system:openshift:scc:anyuid'

--- a/pod-security-rbac/monitoring-ns-rolebinding.yaml
+++ b/pod-security-rbac/monitoring-ns-rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+ name: rhods-monitoring-scc
+subjects:
+ - kind: Group
+   apiGroup: rbac.authorization.k8s.io
+   name: 'system:serviceaccounts:redhat-ods-monitoring'
+roleRef:
+ apiGroup: rbac.authorization.k8s.io
+ kind: ClusterRole
+ name: 'system:openshift:scc:anyuid'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
1. Setup 4.12 Openshift cluster
2. Install the live-build
3. Verify pods are deployed successfully in `redhat-ods-monitoring` and `redhat-ods-applications` namespace

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-5453 
- [x] The Jira story is acked.
- [ ] Live build image: quay.io/modh/rhods-operator-live-catalog:1.21.0-rhods-5453
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
