### PR TITLE
Fix Security policies for prometheus container

### DIFF
--- a/monitoring/prometheus/prometheus.yaml
+++ b/monitoring/prometheus/prometheus.yaml
@@ -270,7 +270,11 @@ spec:
       restartPolicy: Always
       progressDeadlineSeconds: 2400
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
       terminationGracePeriodSeconds: 90
       volumes:
       - name: prometheus-data


### PR DESCRIPTION
PR #290 added a Pod Security policy for prometheus pods, but some paths were mounted as read-only. This PR will grant permissions to prometheus pod to write data as expected.

## Description
Added a securityContext so volumes can be mounted as read-write.

## How Has This Been Tested?
* Deploy RHODS with the live build image below
* Check if prometheus pod in `redhat-ods-monitoring` namespace is running with no CrashLoopbackOff state

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [X] Live build image: quay.io/rmartine/rhods-operator-live-catalog:1.21.0-1
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
