### PR TITLE
Fix issue in ServingRuntime ConfigMap enablement

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -104,20 +104,30 @@ function oc::object::safe::to::apply() {
 function add_servingruntime_config() {
   # Get OpenVino image from latest CSV
   openvino_img=$(oc get csv -l operators.coreos.com/rhods-operator.redhat-ods-operator -n $ODH_OPERATOR_PROJECT -o=jsonpath='{.items[-1].spec.install.spec.deployments[?(@.name == "rhods-operator")].spec.template.spec.containers[?(@.name == "rhods-operator")].env[?(@.name == "RELATED_IMAGE_ODH_OPENVINO_IMAGE")].value}')
+    
   # Replace image
   sed -i "s|<openvino_image>|${openvino_img}|g" model-mesh/serving_runtime_config.yaml
 
-  exists=$(oc get -n $ODH_PROJECT configmap/servingruntimes-config -o name | grep configmap/servingruntimes-config || echo "false")
-  if [ "$exists" == "false" ]; then
+  # Check if the configmap exists
+  configmap_exists=$(oc get -n $ODH_PROJECT configmap/servingruntimes-config -o name | grep configmap/servingruntimes-config || echo "false")
+
+  # Check if the key default-config exists
+  default_config_key_exists=$(oc get -n $ODH_PROJECT configmap/servingruntimes-config -o jsonpath='{.data}' | grep "default-config" || echo "false")
+
+  if [ "$configmap_exists" == "false" ]; then
+    echo "ConfigMap servingruntimes-config doesn't exist, creating it with the default configuration"
+    oc apply -f model-mesh/serving_runtime_config.yaml -n $ODH_PROJECT
+    return 0
+  elif [ "$default_config_key_exists" == "false" ]; then
+    echo "Key default-config doesn't exist in ConfigMap servingruntimes-config applying the key"
+    oc patch -n $ODH_PROJECT configmap/servingruntimes-config --patch-file model-mesh/serving_runtime_config.yaml
     return 0
   else
-    openvino_exists=$(oc get -n $ODH_PROJECT configmap/servingruntimes-config -o jsonpath='{.data}' | grep "default-config" || echo "false")
-    if [ "$openvino_exists" != "false" ]; then
-      return 0
-    fi
+    echo "Key default-config exists in ConfigMap servingruntimes-config, reverting the configuration to the initial state and updating openvino image"
+    oc patch -n $ODH_PROJECT configmap/servingruntimes-config --patch-file model-mesh/serving_runtime_config.yaml
+    return 0
   fi
   return 1
-
 }
 
 ODH_PROJECT=${ODH_CR_NAMESPACE:-"redhat-ods-applications"}
@@ -328,9 +338,8 @@ oc create -n ${ODH_PROJECT} -f model-mesh/etcd-secrets.yaml || echo "WARN: Model
 oc create -n ${ODH_PROJECT} -f model-mesh/etcd-users.yaml || echo "WARN: Etcd user secret was not created successfully."
 
 # Configure Serving Runtime resources
-if add_servingruntime_config; then
-  oc apply -f model-mesh/serving_runtime_config.yaml -n $ODH_PROJECT
-fi
+echo "Creating Serving Runtime resources..."
+add_servingruntime_config
 
 # Add segment.io secret key & configmap
 oc apply -n ${ODH_PROJECT} -f monitoring/segment-key-secret.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fix issue with the deployment of the servingruntimes-config ConfigMap 
Fix https://issues.redhat.com/browse/RHODS-6779

<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Update from a previous version without a “default-config” key -> A “default-config” key must be created with the latest version in odh-deployer ✅
* Update from a previous version with a “default-config” key -> We should revert back the default-config, an override-config is targeted for custom deployments ✅
* Update from a previous version with no configmap -> We need to create the configmap with a default version ✅


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-6779
- [X] The Jira story is acked.
- [X] Live build image: [quay.io/lferrnan/rhods-operator-live-catalog:1.22.0-rhods-ga](http://quay.io/lferrnan/rhods-operator-live-catalog:1.22.0-rhods-ga)
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.

