### PR TITLE
Add Kfdef for Data Science pipelines operator

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -190,6 +190,13 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Create Kfdef for RHODS Data Science pipelines operator
+oc apply -n ${ODH_PROJECT} -f rhods-data-science-pipelines-operator.yaml
+if [ $? -ne 0 ]; then
+  echo "ERROR: Attempt to create the Data Science Pipelines Operator CR failed."
+  exit 1
+fi
+
 # Create KfDef for RHODS Notebooks ImageStreams
 oc apply -n ${ODH_NOTEBOOK_PROJECT} -f rhods-notebooks.yaml
 if [ $? -ne 0 ]; then

--- a/kfdefs/rhods-data-science-pipelines-operator.yaml
+++ b/kfdefs/rhods-data-science-pipelines-operator.yaml
@@ -1,14 +1,33 @@
 apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:
-   name: data-science-pipelines-operator
+  name: rhods-data-science-pipelines-operator
 spec:
-   applications:
-      - kustomizeConfig:
-           repoRef:
-              name: manifests
-              path: data-science-pipelines-operator/
-        name: data-science-pipelines-operator
+  applications:
+    - kustomizeConfig:
+        parameters:
+          - name: IMAGES_APISERVER
+            value: ${RELATED_IMAGE_ODH_ML_PIPELINES_API_SERVER_IMAGE}
+          - name: IMAGES_ARTIFACT
+            value: ${RELATED_IMAGE_ODH_ML_PIPELINES_ARTIFACT_MANAGER_IMAGE}
+          - name: IMAGES_PERSISTENTAGENT
+            value: ${RELATED_IMAGE_ODH_ML_PIPELINES_PERSISTENCEAGENT_IMAGE}
+          - name: IMAGES_SCHEDULEDWORKFLOW
+            value: ${RELATED_IMAGE_ODH_ML_PIPELINES_SCHEDULEDWORKFLOW_IMAGE}
+          - name: IMAGES_VIEWERCRD
+            value: ${RELATED_IMAGE_ODH_ML_PIPELINES_VIEWERCONTROLLER_IMAGE}
+          - name: IMAGES_CACHE
+            value: ${RELATED_IMAGE_ODH_ML_PIPELINES_CACHE_IMAGE}
+          - name: IMAGES_DSPO
+            value: ${RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_OPERATOR_CONTROLLER_IMAGE}
+          - name: IMAGES_MOVERESULTSIMAGE
+            value: registry.redhat.io/ubi8/ubi-micro:8.7
+          - name: IMAGES_MARIADB
+            value: registry.redhat.io/rhel8/mariadb-103:1
+        repoRef:
+          name: manifests
+          path: data-science-pipelines-operator/
+      name: data-science-pipelines-operator
   repos:
     - name: manifests
       uri: file:///opt/manifests/odh-manifests.tar.gz

--- a/kfdefs/rhods-data-science-pipelines-operator.yaml
+++ b/kfdefs/rhods-data-science-pipelines-operator.yaml
@@ -1,0 +1,15 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+   name: data-science-pipelines-operator
+spec:
+   applications:
+      - kustomizeConfig:
+           repoRef:
+              name: manifests
+              path: data-science-pipelines-operator/
+        name: data-science-pipelines-operator
+  repos:
+    - name: manifests
+      uri: file:///opt/manifests/odh-manifests.tar.gz
+  version: v1.0.0


### PR DESCRIPTION
Enables Data Science Pipelines Operator as a Kfdef CR

## Description
This will add Data Science Pipelines Operator as a Kfdef to deploy DSP in a multi-stack architecture. DSPO will be deployed on `redhat-ods-applications` namespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
PRs for [RHODS-6926](https://issues.redhat.com/browse/RHODS-6926), [RHODS-739](https://issues.redhat.com/browse/RHODS-7399), and [RHODS-7400](https://issues.redhat.com/browse/RHODS-7400) must be merged first

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-7151
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
