### PR TITLE
Updated GitHub repo links for quickstart and category labels

### DIFF
--- a/odh-dashboard/apps-managed-service/starburst/starburst-galaxy-quickstart.yaml
+++ b/odh-dashboard/apps-managed-service/starburst/starburst-galaxy-quickstart.yaml
@@ -1,9 +1,8 @@
-apiVersion: console.openshift.io/v1
-kind: OdhQuickStart
+kind: ConsoleQuickStart
 metadata:
   name: using-starburst-galaxy
   annotations:
-    opendatahub.io/categories: 'Getting started,Data management,Data analysis'
+    opendatahub.io/categories: 'Getting started,Starburst Galaxy'
 spec:
   displayName: Querying data with Starburst Galaxy
   appName: starburst
@@ -16,7 +15,7 @@ spec:
 
     In a matter of minutes, you will be able to access data from multiple sources with a single query using a Jupyter notebook.
 
-    Before you begin, please be sure to clone the [Starburst Galaxy 101 GitHub repo](https://github.com/starburstdata/rhods-starburst-galaxy-101.git) to your local machine.
+    Before you begin, please be sure to clone the [Starburst Galaxy 101 GitHub repo](https://github.com/starburstdata/rhods-starburst-101.git) to your local machine.
 
     A recording of this quickstart is available [here](https://developers.redhat.com/articles/2021/11/22/access-more-data-your-jupyter-notebook) in case you are unsure of how to complete any of the tasks.
   tasks:
@@ -82,7 +81,7 @@ spec:
     - title: Run the **explore-data.ipynb** Jupyter notebook
       description: |-
         ### To run the **explore-data.ipynb** notebook:
-        1. If you haven't already done so, clone the [Starburst Galaxy 101 GitHub repo](https://github.com/starburstdata/rhods-starburst-galaxy-101) to your local machine.
+        1. If you haven't already done so, clone the [Starburst Galaxy 101 GitHub repo](https://github.com/starburstdata/rhods-starburst-101) to your local machine.
         2. Open the **explore-data.ipynb** notebook within your JupyterLab interface.
         3. Follow the instructions provided in the notebook to install the required packages and initialize the environment.
         4. Run the cells under the **What is Starburst Galaxy and how does it work?** section to confirm you are connected to your Starburst Galaxy cluster.

--- a/odh-dashboard/apps-managed-service/starburst/starburst-galaxy-quickstart.yaml
+++ b/odh-dashboard/apps-managed-service/starburst/starburst-galaxy-quickstart.yaml
@@ -2,7 +2,7 @@ kind: ConsoleQuickStart
 metadata:
   name: using-starburst-galaxy
   annotations:
-    opendatahub.io/categories: 'Getting started,Starburst Galaxy'
+    opendatahub.io/categories: 'Getting started,Starburst Galaxy,Data management,Data analysis'
 spec:
   displayName: Querying data with Starburst Galaxy
   appName: starburst


### PR DESCRIPTION
## Description
The GitHub repo for the RHODS + Starburst Galaxy quickstart has move to https://github.com/starburstdata/rhods-starburst-101.git, so the links in this file have been updated accordingly.

Additionally, the "Starburst Galaxy" category was added to the tile.

## How Has This Been Tested?
Both of these changes have been tested locally and have been confirmed to be working as expected.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
