### PR TITLE
Add DSP Application recording rules and scrape configs

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -274,6 +274,58 @@ data:
             instance: data-science-pipelines-operator
           record: probe_success:burnrate6h
 
+      - name: SLOs - Data Science Pipelines Application
+        rules:
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[1d]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[1d]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate1d
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[1h]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[1h]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate1h
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[2h]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[2h]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate2h
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[30m]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[30m]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate30m
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[3d]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[3d]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate3d
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[5m]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[5m]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate5m
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[6h]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[6h]))
+          labels:
+            route: ds-pipeline-sample
+          record: haproxy_backend_http_responses_total:burnrate6h
+
       - name: Usage Metrics
         rules:
         - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
@@ -546,7 +598,7 @@ data:
             sum(probe_success:burnrate1d{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
           for: 1h
           labels:
-            severity: warning  
+            severity: warning
 
       - name: RHODS Notebook controllers
         rules:
@@ -730,6 +782,22 @@ data:
       metric_relabel_configs:
         - target_label: namespace
           replacement: redhat-ods-applications
+
+    - job_name: 'Data Science Pipelines Application'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(ds-pipeline-.*)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):8888
+          target_label: __address__
+          action: keep
 
     - job_name: 'RHODS Metrics'
       honor_labels: true

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -277,51 +277,51 @@ data:
       - name: SLOs - Data Science Pipelines Application
         rules:
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[1d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1d]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[1d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1d]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate1d
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[1h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1h]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[1h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1h]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate1h
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[2h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[2h]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[2h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[2h]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate2h
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[30m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[30m]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[30m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[30m]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate30m
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[3d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[3d]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[3d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[3d]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate3d
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[5m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[5m]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[5m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[5m]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate5m
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample",code=~"5.."}[6h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[6h]))
             /
-            sum(rate(haproxy_backend_http_responses_total{route="ds-pipeline-sample"}[6h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[6h]))
           labels:
             route: ds-pipeline-sample
           record: haproxy_backend_http_responses_total:burnrate6h

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -277,53 +277,53 @@ data:
       - name: SLOs - Data Science Pipelines Application
         rules:
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1d])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1d])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate1d
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1h])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1h])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate1h
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[2h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[2h])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[2h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[2h])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate2h
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[30m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[30m])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[30m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[30m])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate30m
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[3d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[3d])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[3d]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[3d])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate3d
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[5m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[5m])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[5m]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[5m])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate5m
         - expr: |
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[6h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[6h])) by (exported_namespace)
             /
-            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[6h]))
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[6h])) by (exported_namespace)
           labels:
-            route: ds-pipeline-sample
+            component: dsp
           record: haproxy_backend_http_responses_total:burnrate6h
 
       - name: Usage Metrics
@@ -798,6 +798,10 @@ data:
           regex: (.+):8888
           target_label: __address__
           action: keep
+        - source_labels: [__meta_kubernetes_service_name]
+          target_label: dspa_service
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
 
     - job_name: 'RHODS Metrics'
       honor_labels: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding Prometheus configuration and recording rules for Data Science Pipelines' Application.

## Description
<!--- Describe your changes in detail -->
- Using olminstall, trigger first a clean build with the image `quay.io/rhn_support_ddalvi/rhods-operator-live-catalog:1.25.0-rhods-7876`. Make sure that the installation is successful
- Go to the prometheus instance url in the `redhat-ods-monitoring` namespace, query the recording rules, make sure that they return entries and values relevant to the data science pipelines' application

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-7876
- [x] The Jira story is acked.
- [x] Live build image: quay.io/rhn_support_ddalvi/rhods-operator-live-catalog:1.25.0-rhods-7876
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
