### PR TITLE
Use sha images for all dspo images.

### DIFF
--- a/kfdefs/rhods-data-science-pipelines-operator.yaml
+++ b/kfdefs/rhods-data-science-pipelines-operator.yaml
@@ -21,9 +21,9 @@ spec:
           - name: IMAGES_DSPO
             value: ${RELATED_IMAGE_ODH_DATA_SCIENCE_PIPELINES_OPERATOR_CONTROLLER_IMAGE}
           - name: IMAGES_MOVERESULTSIMAGE
-            value: registry.redhat.io/ubi8/ubi-micro:8.7
+            value: registry.redhat.io/ubi8/ubi-micro@sha256:6a56010de933f172b195a1a575855d37b70a4968be8edb35157f6ca193969ad2
           - name: IMAGES_MARIADB
-            value: registry.redhat.io/rhel8/mariadb-103:1
+            value: registry.redhat.io/rhel8/mariadb-103@sha256:08c90a8f133b4cdb1477a742bc44be4d8fc4e88153b8bc2a2a148cbdf19f4e7d
         repoRef:
           name: manifests
           path: data-science-pipelines-operator/


### PR DESCRIPTION
## Description
For disconnected installs we need to use only sha images, and not tags.

## How Has This Been Tested?

Live builder image: `quay.io/hukhan/rhods-operator-live-catalog:1.25.0-sha-1-25`
Depoy rhods via live builder, deploy DSPA, create a run.

## Merge criteria:


- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s):
  * https://issues.redhat.com/browse/RHODS-7916
- [ ] The Jira story is acked.
- [x] Live build image: `quay.io/hukhan/rhods-operator-live-catalog:1.25.0-sha-1-25` [(upstream_source.yaml)](https://gist.github.com/HumairAK/cacbdd222e4f239527d5053ee1021c33)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [] QE contact acknowledges that this has been tested and is approved for merge.
