### PR TITLE
Update owners to have a dspo rep as approver.

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,6 +2,7 @@ aliases:
   # folks who can approve and APPROVED any PRs in the repo
   dev-approvers:
     - anishasthana
+    - HumairAK
     - LaVLaS
     - lucferbux
     - VaishnaviHire
@@ -13,5 +14,5 @@ aliases:
     - VaishnaviHire
   # folks who can review/test and QE-APPROVED any PRs in the repo
   qe-approvers:
-    - pablofelix
+    - jgarciao
     - tarukumar


### PR DESCRIPTION
## Description
It probably makes sense to have one of the dspo component owners to be able to dev-approve prs pertaining to DSPO/DSP. 

cc @accorvin 

## How Has This Been Tested?
No code change.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.

The following does not apply as this is not a code change.

- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
