### PR TITLE
Remove getting OVMS image from the CSV, use hardcoded

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -102,8 +102,8 @@ function oc::object::safe::to::apply() {
 }
 
 function add_servingruntime_config() {
-  # Get OpenVino image from latest CSV
-  openvino_img=$(oc get csv -l operators.coreos.com/rhods-operator.redhat-ods-operator -n $ODH_OPERATOR_PROJECT -o=jsonpath='{.items[-1].spec.install.spec.deployments[?(@.name == "rhods-operator")].spec.template.spec.containers[?(@.name == "rhods-operator")].env[?(@.name == "RELATED_IMAGE_ODH_OPENVINO_IMAGE")].value}')
+  # Replace OpenVINO Model Server image in servingruntime config
+  openvino_img='quay.io/modh/openvino-model-server@sha256:c89f76386bc8b59f0748cf173868e5beef21ac7d2f78dada69089c4d37c44116'
     
   # Replace image
   sed -i "s|<openvino_image>|${openvino_img}|g" model-mesh/serving_runtime_config.yaml

--- a/kfdefs/rhods-model-mesh.yaml
+++ b/kfdefs/rhods-model-mesh.yaml
@@ -12,8 +12,6 @@ spec:
           value: ${RELATED_IMAGE_ODH_MODELMESH_RUNTIME_ADAPTER_IMAGE}
         - name: odh-modelmesh
           value: ${RELATED_IMAGE_ODH_MODELMESH_IMAGE}
-        - name: odh-openvino
-          value: ${RELATED_IMAGE_ODH_OPENVINO_IMAGE}
         - name: odh-modelmesh-controller
           value: ${RELATED_IMAGE_ODH_MODELMESH_CONTROLLER_IMAGE}
         - name: odh-model-controller


### PR DESCRIPTION
With the change to the quay.io image, we can the logic for getting this from the CSV

This is related to https://github.com/red-hat-data-services/odh-manifests/pull/328

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [X] JIRA link(s): 
- [X] The Jira story is acked.
- [ ] Live build image: 
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
