### PR TITLE
Add an alert for detecting stuck deployment rollouts

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -706,6 +706,14 @@ data:
           for: 5m
           labels:
             severity: warning
+        - alert: Controller rollout is stuck
+          annotations:
+            message: 'Rollout of controller {{ $labels.deployment }} is stuck.'
+            summary: A RHODS controller deployment upgrade is stuck.
+          expr: sum(kube_deployment_status_condition{condition="Progressing", status="false"}) by (deployment) != 0
+          for: 30m
+          labels:
+            severity: warning
 
   prometheus.yml: |
     rule_files:


### PR DESCRIPTION
## Description

Alerts of deployment not progressing (whatever the reason) for ODH controllers.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-8152
- [x] Live build image: quay.io/modh/rhods-operator-live-catalog:1.27.0-rhods-8152
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
