### PR TITLE
Add DataSciencePipelinesApplication Readiness Alerts

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -707,6 +707,44 @@ data:
           labels:
             severity: warning
 
+      - name: RHODS Data Science Pipelines
+        rules:
+        - alert: Data Science Pipeline Application Unavailable
+          annotations:
+            message: 'Data Science Pipelines Application is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: The Data Science Pipelines Application CustomResource "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipeline APIServer Unavailable
+          annotations:
+            message: 'Data Science Pipelines APIServer component is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: A Data Science Pipelines APIServer pod owned by DSPA "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_apiserver_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipeline PersistenceAgent Unavailable
+          annotations:
+            message: 'Data Science Pipelines PersistenceAgent component is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: A Data Science Pipelines PersistenceAgent pod owned by DSPA "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_persistenceagent_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipeline ScheduledWorkflows Unavailable
+          annotations:
+            message: 'Data Science Pipelines ScheduledWorkflows component is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: A Data Science Pipelines ScheduledWorkflow controller pod owned by DSPA "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_scheduledworkflow_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
   prometheus.yml: |
     rule_files:
       - '*.rules'


### PR DESCRIPTION
Add info alerts to utilize the DSPA *Ready conditions

## Description
Add alerts, 1 for each CR Status Condition for 4 in total, that will trigger if any DSPA is not in a Ready state for 5 continous minutes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): [RHODS-7777](https://issues.redhat.com/browse/RHODS-7777)
- [x] The Jira story is acked.
- [x] Live build image: [quay.io/gmfrasca/rhods-operator-live-catalog:2.0.3-dspa-ready-alerts](quay.io/gmfrasca/rhods-operator-live-catalog:2.0.3-dspa-ready-alerts)
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
