### PR TITLE
add cluster monitoring label to applications namespace

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -120,6 +120,8 @@ oc label namespace $ODH_MONITORING_PROJECT openshift.io/cluster-monitoring=true 
 oc label namespace $ODH_MONITORING_PROJECT  $NAMESPACE_LABEL --overwrite=true || echo "INFO: ${NAMESPACE_LABEL} label already exists."
 oc label namespace $ODH_MONITORING_PROJECT  $POD_SECURITY_LABEL --overwrite=true || echo "INFO: ${POD_SECURITY_LABEL} label already exists."
 
+oc label namespace $ODH_PROJECT openshift.io/cluster-monitoring=true --overwrite=true
+
 # Create Rolebinding for baseline permissions
 oc apply -n ${ODH_PROJECT} -f pod-security-rbac/applications-ns-rolebinding.yaml
 oc apply -n ${ODH_MONITORING_PROJECT} -f pod-security-rbac/monitoring-ns-rolebinding.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Add cluster monitoring label to `redhat-ods-applications`
<!--- Describe your changes in detail -->
https://issues.redhat.com/browse/RHODS-7978

## How Has This Been Tested?
verified namespace label with live-builder image 
#### Testing Instructions:
- install live builder image
- verify `redhat-ods-applications` has the label `openshift.io/cluster-monitoring=true`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-7978
- [x] The Jira story is acked.
- [x] Live build image: `quay.io/vedantm/rhods-operator-live-catalog:1.28.0-7978`
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
