### PR TITLE
Fix startbust enablement when installing operator

### DIFF
--- a/odh-dashboard/apps-on-prem/starburst-enterprise/starburstenterprise-app.yaml
+++ b/odh-dashboard/apps-on-prem/starburst-enterprise/starburstenterprise-app.yaml
@@ -15,6 +15,7 @@ spec:
   route:
   category: Self-managed
   support: Starburst
+  csvName: starburst-enterprise-helm-operator
   docsLink: https://docs.starburst.io/latest/overview.html
   quickStart: using-starburst-enterprise
   getStartedLink: https://docs.starburst.io/ecosystems/redhat/openshift-deployment.html


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix issue when installing starbust enterprise the app didn't appear as enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Install startbus enterprise operator
2. Check that the app has been enabled

<img width="1081" alt="Screenshot 2023-06-13 at 17 32 05" src="https://github.com/red-hat-data-services/odh-deployer/assets/16117276/a9e70fde-b034-4278-9a0d-9735204d9bf5">

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-9327
- [X] The Jira story is acked.
- [X] Live build image: `quay.io/lferrnan/rhods-operator-live-catalog:1.28.0-deployer`
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
