### PR TITLE
Remove tensorflow from the supported runtimes in OOTB Serving Runtimes

### DIFF
--- a/odh-dashboard/modelserving/ovms-gpu-ootb.yaml
+++ b/odh-dashboard/modelserving/ovms-gpu-ootb.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
-    opendatahub.io/configurable: 'true'
   annotations:
     tags: 'ovms,servingruntime'
     description: 'OpenVino with GPU Support Model Serving Definition'
@@ -57,7 +56,4 @@ objects:
         - autoSelect: true
           name: onnx
           version: '1'
-        - autoSelect: true
-          name: tensorflow
-          version: "2"
 parameters: []

--- a/odh-dashboard/modelserving/ovms-ootb.yaml
+++ b/odh-dashboard/modelserving/ovms-ootb.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
-    opendatahub.io/configurable: 'true'
   annotations:
     tags: 'ovms,servingruntime'
     description: 'OpenVino Model Serving Definition'
@@ -55,7 +54,4 @@ objects:
         - autoSelect: true
           name: onnx
           version: '1'
-        - autoSelect: true
-          name: tensorflow
-          version: "2"
 parameters: []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Based on the outcome of https://issues.redhat.com/browse/RHODS-8874 it seems that ovms is not supporting tensorflow as previously suggested.

Removing the runtime selection for the OOTB models.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Deploy the runtimes with `oc apply -k odh-dashboard/modelserving`
2. Deploy a new model
3. Select OOTB Serving Runtime
4. Check that the Serving Runtime doesn't include tensorflow

@lugi0 I haven't tested the upgrade, I'll try to do it on Monday, I'm working in other things.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
