### PR TITLE
Remove old DSPO deployment for correct RHODS upgrade

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -147,6 +147,16 @@ oc get catalogsource -n ${ODH_OPERATOR_PROJECT} addon-managed-odh-catalog || RHO
   fi
  fi
 
+# TODO: This is a part of the 1.28->1.29 upgrade so it needs to be removed in 1.30
+# Labels for DSPO have been updated so the old DSPO deployment needs to be removed for proper upgrade
+ export old_dspo_deployment_exit=true
+ oc get deployment controller-manager -n ${ODH_PROJECT}  > /dev/null 2>&1|| old_dspo_deployment_exit=false
+ if [[ ${old_dspo_deployment_exit} != "false" ]];then
+  if [[ $(oc get deployment controller-manager -n ${ODH_PROJECT} -o jsonpath='{.metadata.labels.control-plane}') == "controller-manager" ]]; then
+     oc delete deployment controller-manager -n ${ODH_PROJECT}
+  fi
+ fi
+
 # TODO: Remove in 1.21
 # If buildconfigs with label rhods/buildchain=cuda-* found, delete them (replaced by pre-build notebooks).
 oc delete buildconfig -n redhat-ods-applications -l rhods/buildchain


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Labels for DSPO have been updated so the old DSPO deployment needs to be removed for proper upgrade from one RHODS version to another.

Related issue: https://github.com/opendatahub-io/data-science-pipelines-operator/issues/140

Depends on: https://github.com/red-hat-data-services/odh-manifests/pull/413

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
