### PR TITLE
Correct dspo deployment for cleanup.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -147,15 +147,15 @@ oc get catalogsource -n ${ODH_OPERATOR_PROJECT} addon-managed-odh-catalog || RHO
   fi
  fi
 
-# TODO: This is a part of the 1.28->1.29 upgrade so it needs to be removed in 1.30
 # Labels for DSPO have been updated so the old DSPO deployment needs to be removed for proper upgrade
- export old_dspo_deployment_exit=true
- oc get deployment controller-manager -n ${ODH_PROJECT}  > /dev/null 2>&1|| old_dspo_deployment_exit=false
- if [[ ${old_dspo_deployment_exit} != "false" ]];then
-  if [[ $(oc get deployment controller-manager -n ${ODH_PROJECT} -o jsonpath='{.metadata.labels.control-plane}') == "controller-manager" ]]; then
-     oc delete deployment controller-manager -n ${ODH_PROJECT}
+export old_dspo_deployment_exit=true
+DSPO_DEPLOYMENT=data-science-pipelines-operator-controller-manager
+oc get deployment ${DSPO_DEPLOYMENT} -n ${ODH_PROJECT}  > /dev/null 2>&1 || old_dspo_deployment_exit=false
+if [[ ${old_dspo_deployment_exit} != "false" ]];then
+  if [[ $(oc get deployment ${DSPO_DEPLOYMENT} -n ${ODH_PROJECT} -o jsonpath='{.metadata.labels.control-plane}') == "controller-manager" ]]; then
+     oc delete deployment ${DSPO_DEPLOYMENT} -n ${ODH_PROJECT}
   fi
- fi
+fi
 
 # TODO: Remove in 1.21
 # If buildconfigs with label rhods/buildchain=cuda-* found, delete them (replaced by pre-build notebooks).


### PR DESCRIPTION
## Description
Corrects: https://github.com/red-hat-data-services/odh-deployer/pull/364 
Currently 364 does not fix the regression introduced via https://github.com/opendatahub-io/data-science-pipelines-operator/pull/170

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-10488
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
