### PR TITLE
feat: addition of codeflare stack to monitoring

### DIFF
--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -745,6 +745,43 @@ data:
           for: 2m
           labels:
             severity: info
+
+      - name: Distributed Workloads Kuberay
+        interval: 1m
+        rules:
+          - alert: KubeRay Operator is not running
+            expr: absent(up{job=~'KubeRay Operator'})
+            labels:
+              severity: warning
+            annotations:
+              description: This alert fires when the KubeRay Operator is not running.
+              triage:
+              summary: Alerting for KubeRay Operator
+          
+      - name: Distributed Workloads MCAD
+        interval: 1m
+        rules:
+          - alert: MCAD is not running
+            expr: absent(up{job=~'MCAD Controller'})
+            labels:
+              severity: warning
+            annotations:
+              description: This alert fires when the MCAD Controller is not running.
+              triage:
+              summary: Alerting for MCAD Controller
+
+      - name: Distributed Workloads CodeFlare
+        interval: 1m
+        rules:
+          - alert: CodeFlare Operator is not running
+            expr: absent(up{job=~'CodeFlare Operator'})
+            labels:
+              severity: warning
+            annotations:
+              description: This alert fires when the CodeFlare Operator is not running.
+              triage:
+              summary: Alerting for CodeFlare Operator 
+
   prometheus.yml: |
     rule_files:
       - '*.rules'
@@ -926,6 +963,63 @@ data:
           target_label: dspa_service
         - source_labels: [__meta_kubernetes_namespace]
           target_label: namespace
+
+    - job_name: 'KubeRay Operator'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(kuberay-operator)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'MCAD Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(mcad-mcad-metrics)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:9090
+
+    - job_name: 'CodeFlare Operator'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - openshift-operators
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(codeflare-operator-manager-metrics)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
 
     - job_name: 'RHODS Metrics'
       honor_labels: true

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -274,44 +274,6 @@ data:
             instance: data-science-pipelines-operator
           record: probe_success:burnrate6h
 
-      - name: SLOs - MCAD Controller
-        rules:
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[1d])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate1d
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[1h])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate1h
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[2h])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate2h
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[30m])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate30m
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[3d])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate3d
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[5m])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate5m
-        - expr: |
-            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[6h])
-          labels:
-            instance: mcad-controller
-          record: probe_success:burnrate6h
-
       - name: SLOs - CodeFlare Operator
         rules:
         - expr: |
@@ -762,43 +724,6 @@ data:
           labels:
             severity: warning
 
-        - alert: MCAD Controller Probe Success Burn Rate
-          annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-probe-success-burn-rate.md'
-            summary: MCAD Controller Probe Success Burn Rate
-          expr: |
-            sum(probe_success:burnrate5m{instance=~"mcad-controller"}) by (instance) > (14.40 * (1-0.99950))
-            and
-            sum(probe_success:burnrate1h{instance=~"mcad-controller"}) by (instance) > (14.40 * (1-0.99950))
-          for: 2m
-          labels:
-            severity: warning
-        - alert: MCAD Controller Probe Success Burn Rate
-          annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-probe-success-burn-rate.md'
-            summary: MCAD Controller Probe Success Burn Rate
-          expr: |
-            sum(probe_success:burnrate30m{instance=~"mcad-controller"}) by (instance) > (6.00 * (1-0.99950))
-            and
-            sum(probe_success:burnrate6h{instance=~"mcad-controller"}) by (instance) > (6.00 * (1-0.99950))
-          for: 15m
-          labels:
-            severity: warning
-        - alert: MCAD Controller Probe Success Burn Rate
-          annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-probe-success-burn-rate.md'
-            summary: MCAD Controller Probe Success Burn Rate
-          expr: |
-            sum(probe_success:burnrate2h{instance=~"mcad-controller"}) by (instance) > (3.00 * (1-0.99950))
-            and
-            sum(probe_success:burnrate1d{instance=~"mcad-controller"}) by (instance) > (3.00 * (1-0.99950))
-          for: 1h
-          labels:
-            severity: warning
-
         - alert: CodeFlare Operator Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
@@ -907,26 +832,6 @@ data:
               description: This alert fires when the KubeRay Operator is not running.
               triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'
               summary: Alerting for KubeRay Operator
-          
-      - name: Distributed Workloads MCAD
-        interval: 1m
-        rules:
-          - alert: MCAD is not running
-            expr: absent(up{job=~'MCAD Controller'}) or up{job=~'MCAD Controller'} != 1
-            labels:
-              severity: warning
-            annotations:
-              description: This alert fires when the MCAD Controller is not running.
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-availability.md'
-              summary: Alerting for MCAD Controller
-          - alert: MCAD taking too long to be up
-            expr: absent_over_time(up{job="MCAD Controller"}[2m]) == 1
-            labels:
-              severity: warning
-            annotations:
-              description: This alert fires when the MCAD Controller takes over 2 min. to come back online. Either MCAD is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.
-              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-absent-over-time.md'
-              summary: Alerting for MCAD Controller
 
       - name: Distributed Workloads CodeFlare
         interval: 1m
@@ -1005,9 +910,6 @@ data:
       - targets: [<data_science_pipelines_operator_host>]
         labels:
           name: data-science-pipelines-operator
-      - targets: [mcad-mcad-metrics.redhat-ods-applications.svc:8083/metrics]
-        labels:
-          name: mcad-controller
       - targets: [codeflare-operator-manager-metrics.openshift-operators.svc:8080/metrics]
         labels:
           name: codeflare-operator
@@ -1144,7 +1046,7 @@ data:
         - role: endpoints
           namespaces:
             names:
-              - redhat-ods-applications
+              - opendatahub
       relabel_configs:
         - source_labels: [__meta_kubernetes_service_name]
           regex: ^(kuberay-operator)$
@@ -1154,25 +1056,6 @@ data:
           regex: (.+):(\d+)
           target_label: __address__
           replacement: ${1}:8080
-
-    - job_name: 'MCAD Controller'
-      honor_labels: true
-      metrics_path: /metrics
-      scheme: http
-      kubernetes_sd_configs:
-        - role: endpoints
-          namespaces:
-            names:
-              - redhat-ods-applications
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(mcad-mcad-metrics)$
-          target_label: kubernetes_name
-          action: keep
-        - source_labels: [__address__]
-          regex: (.+):(\d+)
-          target_label: __address__
-          replacement: ${1}:8083
 
     - job_name: 'CodeFlare Operator'
       honor_labels: true

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -910,7 +910,7 @@ data:
       - targets: [<data_science_pipelines_operator_host>]
         labels:
           name: data-science-pipelines-operator
-      - targets: [codeflare-operator-manager-metrics.openshift-operators.svc:8080/metrics]
+      - targets: [codeflare-operator-manager-metrics.redhat-ods-applications.svc:8080/metrics]
         labels:
           name: codeflare-operator
       relabel_configs:
@@ -1046,7 +1046,7 @@ data:
         - role: endpoints
           namespaces:
             names:
-              - opendatahub
+              - redhat-ods-applications
       relabel_configs:
         - source_labels: [__meta_kubernetes_service_name]
           regex: ^(kuberay-operator)$
@@ -1065,7 +1065,7 @@ data:
         - role: endpoints
           namespaces:
             names:
-              - openshift-operators
+              - redhat-ods-applications
       relabel_configs:
         - source_labels: [__meta_kubernetes_service_name]
           regex: ^(codeflare-operator-manager-metrics)$

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -274,6 +274,82 @@ data:
             instance: data-science-pipelines-operator
           record: probe_success:burnrate6h
 
+      - name: SLOs - MCAD Controller
+        rules:
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[1d])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[1h])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[2h])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[30m])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[3d])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[5m])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"mcad-controller-.*", job="user_facing_endpoints_status"}[6h])
+          labels:
+            instance: mcad-controller
+          record: probe_success:burnrate6h
+
+      - name: SLOs - CodeFlare Operator
+        rules:
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[1d])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[1h])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[2h])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[30m])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[3d])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[5m])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"codeflare-operator-.*", job="user_facing_endpoints_status"}[6h])
+          labels:
+            instance: codeflare-operator
+          record: probe_success:burnrate6h
+
       - name: SLOs - Data Science Pipelines Application
         rules:
         - expr: |
@@ -686,6 +762,80 @@ data:
           labels:
             severity: warning
 
+        - alert: MCAD Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage:
+            summary: MCAD Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"mcad-controller"}) by (instance) > (14.40 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1h{instance=~"mcad-controller"}) by (instance) > (14.40 * (1-0.99950))
+          for: 2m
+          labels:
+            severity: warning
+        - alert: MCAD Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage:
+            summary: MCAD Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"mcad-controller"}) by (instance) > (6.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate6h{instance=~"mcad-controller"}) by (instance) > (6.00 * (1-0.99950))
+          for: 15m
+          labels:
+            severity: warning
+        - alert: MCAD Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage:
+            summary: MCAD Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"mcad-controller"}) by (instance) > (3.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1d{instance=~"mcad-controller"}) by (instance) > (3.00 * (1-0.99950))
+          for: 1h
+          labels:
+            severity: warning
+
+        - alert: CodeFlare Operator Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage:
+            summary: CodeFlare Operator Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"codeflare-operator"}) by (instance) > (14.40 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1h{instance=~"codeflare-operator"}) by (instance) > (14.40 * (1-0.99950))
+          for: 2m
+          labels:
+            severity: warning
+        - alert: CodeFlare Operator Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage:
+            summary: CodeFlare Operator Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"codeflare-operator"}) by (instance) > (6.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate6h{instance=~"codeflare-operator"}) by (instance) > (6.00 * (1-0.99950))
+          for: 15m
+          labels:
+            severity: warning
+        - alert: CodeFlare Operator Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage:
+            summary: CodeFlare Operator Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"codeflare-operator"}) by (instance) > (3.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1d{instance=~"codeflare-operator"}) by (instance) > (3.00 * (1-0.99950))
+          for: 1h
+          labels:
+            severity: warning
+
       - name: RHODS Notebook controllers
         rules:
         - alert: Kubeflow notebook controller pod is not running
@@ -750,7 +900,7 @@ data:
         interval: 1m
         rules:
           - alert: KubeRay Operator is not running
-            expr: absent(up{job=~'KubeRay Operator'})
+            expr: absent(up{job=~'KubeRay Operator'}) or up{job=~'KubeRay Operator'} != 1
             labels:
               severity: warning
             annotations:
@@ -762,11 +912,19 @@ data:
         interval: 1m
         rules:
           - alert: MCAD is not running
-            expr: absent(up{job=~'MCAD Controller'})
+            expr: absent(up{job=~'MCAD Controller'}) or up{job=~'MCAD Controller'} != 1
             labels:
               severity: warning
             annotations:
               description: This alert fires when the MCAD Controller is not running.
+              triage:
+              summary: Alerting for MCAD Controller
+          - alert: MCAD taking too long to be up
+            expr: absent_over_time(up{job="MCAD Controller"}[2m]) == 1
+            labels:
+              severity: warning
+            annotations:
+              description: This alert fires when the MCAD Controller takes over 2 min. to come back online. Either MCAD is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.
               triage:
               summary: Alerting for MCAD Controller
 
@@ -774,13 +932,21 @@ data:
         interval: 1m
         rules:
           - alert: CodeFlare Operator is not running
-            expr: absent(up{job=~'CodeFlare Operator'})
+            expr: absent(up{job=~'CodeFlare Operator'}) or up{job=~'CodeFlare Operator'} != 1
             labels:
               severity: warning
             annotations:
               description: This alert fires when the CodeFlare Operator is not running.
               triage:
-              summary: Alerting for CodeFlare Operator 
+              summary: Alerting for CodeFlare Operator
+          - alert: CodeFlare Operator taking too long to be up
+            expr: absent_over_time(up{job="CodeFlare Operator"}[2m]) == 1
+            labels:
+              severity: warning
+            annotations:
+              description: This alert fires when the CodeFlare Operator takes over 2 min. to come back online. Either CodeFlare Operator is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.
+              triage:
+              summary: Alerting for CodeFlare Operator
 
   prometheus.yml: |
     rule_files:
@@ -839,6 +1005,12 @@ data:
       - targets: [<data_science_pipelines_operator_host>]
         labels:
           name: data-science-pipelines-operator
+      - targets: [mcad-mcad-metrics.redhat-ods-applications.svc:8083/metrics]
+        labels:
+          name: mcad-controller
+      - targets: [codeflare-operator-manager-metrics.openshift-operators.svc:8080/metrics]
+        labels:
+          name: codeflare-operator
       relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -1000,7 +1172,7 @@ data:
         - source_labels: [__address__]
           regex: (.+):(\d+)
           target_label: __address__
-          replacement: ${1}:9090
+          replacement: ${1}:8083
 
     - job_name: 'CodeFlare Operator'
       honor_labels: true

--- a/monitoring/prometheus/prometheus-configs.yaml
+++ b/monitoring/prometheus/prometheus-configs.yaml
@@ -765,7 +765,7 @@ data:
         - alert: MCAD Controller Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage:
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-probe-success-burn-rate.md'
             summary: MCAD Controller Probe Success Burn Rate
           expr: |
             sum(probe_success:burnrate5m{instance=~"mcad-controller"}) by (instance) > (14.40 * (1-0.99950))
@@ -777,7 +777,7 @@ data:
         - alert: MCAD Controller Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage:
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-probe-success-burn-rate.md'
             summary: MCAD Controller Probe Success Burn Rate
           expr: |
             sum(probe_success:burnrate30m{instance=~"mcad-controller"}) by (instance) > (6.00 * (1-0.99950))
@@ -789,7 +789,7 @@ data:
         - alert: MCAD Controller Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage:
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-probe-success-burn-rate.md'
             summary: MCAD Controller Probe Success Burn Rate
           expr: |
             sum(probe_success:burnrate2h{instance=~"mcad-controller"}) by (instance) > (3.00 * (1-0.99950))
@@ -802,7 +802,7 @@ data:
         - alert: CodeFlare Operator Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage:
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-probe-success-burn-rate.md'
             summary: CodeFlare Operator Probe Success Burn Rate
           expr: |
             sum(probe_success:burnrate5m{instance=~"codeflare-operator"}) by (instance) > (14.40 * (1-0.99950))
@@ -814,7 +814,7 @@ data:
         - alert: CodeFlare Operator Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage:
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-probe-success-burn-rate.md'
             summary: CodeFlare Operator Probe Success Burn Rate
           expr: |
             sum(probe_success:burnrate30m{instance=~"codeflare-operator"}) by (instance) > (6.00 * (1-0.99950))
@@ -826,7 +826,7 @@ data:
         - alert: CodeFlare Operator Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage:
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-probe-success-burn-rate.md'
             summary: CodeFlare Operator Probe Success Burn Rate
           expr: |
             sum(probe_success:burnrate2h{instance=~"codeflare-operator"}) by (instance) > (3.00 * (1-0.99950))
@@ -905,7 +905,7 @@ data:
               severity: warning
             annotations:
               description: This alert fires when the KubeRay Operator is not running.
-              triage:
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'
               summary: Alerting for KubeRay Operator
           
       - name: Distributed Workloads MCAD
@@ -917,7 +917,7 @@ data:
               severity: warning
             annotations:
               description: This alert fires when the MCAD Controller is not running.
-              triage:
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-availability.md'
               summary: Alerting for MCAD Controller
           - alert: MCAD taking too long to be up
             expr: absent_over_time(up{job="MCAD Controller"}[2m]) == 1
@@ -925,7 +925,7 @@ data:
               severity: warning
             annotations:
               description: This alert fires when the MCAD Controller takes over 2 min. to come back online. Either MCAD is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.
-              triage:
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/mcad-controller-absent-over-time.md'
               summary: Alerting for MCAD Controller
 
       - name: Distributed Workloads CodeFlare
@@ -937,7 +937,7 @@ data:
               severity: warning
             annotations:
               description: This alert fires when the CodeFlare Operator is not running.
-              triage:
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-availability.md'
               summary: Alerting for CodeFlare Operator
           - alert: CodeFlare Operator taking too long to be up
             expr: absent_over_time(up{job="CodeFlare Operator"}[2m]) == 1
@@ -945,7 +945,7 @@ data:
               severity: warning
             annotations:
               description: This alert fires when the CodeFlare Operator takes over 2 min. to come back online. Either CodeFlare Operator is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.
-              triage:
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-absent-over-time.md'
               summary: Alerting for CodeFlare Operator
 
   prometheus.yml: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes #373 
## Description
<!--- Describe your changes in detail -->
For reference if needed: https://github.com/red-hat-data-services/odh-deployer/pull/365

The respective SOPs are on these merge requests:
https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/merge_requests/95
https://gitlab.cee.redhat.com/dsaridak/managed-tenants-sops/-/merge_requests/1 

We want the alerts' runbook/triage to point to their SOPs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message.
- [ ] JIRA link(s):
- [ ] The Jira story is acked.
- [ ] Live build image: 
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] QE contact acknowledges that this has been tested and is approved for merge.
